### PR TITLE
fix(commit): default to interactive mode on TTY instead of hanging on stdin

### DIFF
--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -80,8 +80,11 @@ export function registerCommitCommand(
         input = await readInputFromFile(options.file);
       } else if (options.intent) {
         input = buildInputFromFlags(options);
+      } else if (process.stdin.isTTY) {
+        // TTY with no flags: default to interactive mode instead of hanging on stdin
+        input = await collectInteractiveInput(prompt);
       } else {
-        // Default: read JSON from stdin
+        // Piped input: read JSON from stdin
         input = await readInputFromStdin();
       }
 


### PR DESCRIPTION
## Summary
- When no flags are provided and stdin is a TTY, the commit command now defaults to interactive mode instead of blocking indefinitely waiting for piped JSON input
- Priority order is now: `--interactive` -> `--file` -> `--intent` flags -> TTY check (interactive) -> piped stdin

## Test plan
- [ ] Tests pass: `npm test`
- [ ] Type-check passes: `npm run typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)