### PR TITLE
fix(stale): replace broken filter logic with data-driven signal matching

### DIFF
--- a/src/commands/stale.ts
+++ b/src/commands/stale.ts
@@ -7,6 +7,7 @@ import type { IOutputFormatter } from '../interfaces/output-formatter.js';
 import type { LoreAtom, SupersessionStatus } from '../types/domain.js';
 import type { PathQueryOptions } from '../types/query.js';
 import type { FormattableStalenessResult, StaleAtomReport } from '../types/output.js';
+import { STALE_SIGNAL } from '../util/constants.js';
 
 interface StaleCommandOptions {
   readonly olderThan?: string;
@@ -70,9 +71,9 @@ export function registerStaleCommand(
 
       // Apply additional CLI-level filters: keep reports that match ANY active signal
       const activeSignals: string[] = [];
-      if (options.olderThan) activeSignals.push('age');
-      if (options.drift !== undefined) activeSignals.push('drift');
-      if (options.lowConfidence) activeSignals.push('low-confidence');
+      if (options.olderThan) activeSignals.push(STALE_SIGNAL.AGE);
+      if (options.drift !== undefined) activeSignals.push(STALE_SIGNAL.DRIFT);
+      if (options.lowConfidence) activeSignals.push(STALE_SIGNAL.LOW_CONFIDENCE);
       if (activeSignals.length > 0) {
         reports = reports.filter(r => r.reasons.some(reason => activeSignals.includes(reason.signal)));
       }

--- a/src/commands/stale.ts
+++ b/src/commands/stale.ts
@@ -68,32 +68,13 @@ export function registerStaleCommand(
         supersessionMap,
       );
 
-      // Apply additional CLI-level filters
-      if (options.olderThan || options.drift !== undefined || options.lowConfidence) {
-        reports = reports.filter((report) => {
-          const matchesAge = options.olderThan
-            ? report.reasons.some((r) => r.signal === 'age')
-            : true;
-          const matchesDrift = options.drift !== undefined
-            ? report.reasons.some((r) => r.signal === 'drift')
-            : true;
-          const matchesConfidence = options.lowConfidence
-            ? report.reasons.some((r) => r.signal === 'low-confidence')
-            : true;
-
-          // If specific filters are given, require at least one to match
-          if (options.olderThan && !options.drift && !options.lowConfidence) {
-            return matchesAge;
-          }
-          if (!options.olderThan && options.drift !== undefined && !options.lowConfidence) {
-            return matchesDrift;
-          }
-          if (!options.olderThan && options.drift === undefined && options.lowConfidence) {
-            return matchesConfidence;
-          }
-
-          return matchesAge || matchesDrift || matchesConfidence;
-        });
+      // Apply additional CLI-level filters: keep reports that match ANY active signal
+      const activeSignals: string[] = [];
+      if (options.olderThan) activeSignals.push('age');
+      if (options.drift !== undefined) activeSignals.push('drift');
+      if (options.lowConfidence) activeSignals.push('low-confidence');
+      if (activeSignals.length > 0) {
+        reports = reports.filter(r => r.reasons.some(reason => activeSignals.includes(reason.signal)));
       }
 
       const stalenessResult: FormattableStalenessResult = {

--- a/src/services/staleness-detector.ts
+++ b/src/services/staleness-detector.ts
@@ -2,7 +2,7 @@ import type { IGitClient } from '../interfaces/git-client.js';
 import type { LoreConfig } from '../types/config.js';
 import type { LoreAtom, SupersessionStatus } from '../types/domain.js';
 import type { StaleAtomReport, StaleReason } from '../types/output.js';
-import { LORE_ID_PATTERN } from '../util/constants.js';
+import { LORE_ID_PATTERN, STALE_SIGNAL } from '../util/constants.js';
 
 /**
  * Multi-signal staleness detection for Lore atoms.
@@ -74,7 +74,7 @@ export class StalenessDetector {
     if (ageMs > maxAgeMs) {
       const ageDescription = this.formatAge(ageMs);
       reasons.push({
-        signal: 'age',
+        signal: STALE_SIGNAL.AGE,
         description: `Atom is ${ageDescription} old (threshold: ${this.config.stale.olderThan})`,
       });
     }
@@ -96,7 +96,7 @@ export class StalenessDetector {
         );
         if (commitsSince > this.config.stale.driftThreshold) {
           reasons.push({
-            signal: 'drift',
+            signal: STALE_SIGNAL.DRIFT,
             description: `${filePath} has ${commitsSince} commits since this atom (threshold: ${this.config.stale.driftThreshold})`,
           });
         }
@@ -112,7 +112,7 @@ export class StalenessDetector {
   private checkLowConfidence(atom: LoreAtom, reasons: StaleReason[]): void {
     if (atom.trailers.Confidence === 'low') {
       reasons.push({
-        signal: 'low-confidence',
+        signal: STALE_SIGNAL.LOW_CONFIDENCE,
         description: 'Atom is marked as Confidence: low',
       });
     }
@@ -140,7 +140,7 @@ export class StalenessDetector {
 
         if (expiryDate !== null && now > expiryDate) {
           reasons.push({
-            signal: 'expired-hint',
+            signal: STALE_SIGNAL.EXPIRED_HINT,
             description: `Directive "${directive}" has expired [until:${dateStr}]`,
           });
         }
@@ -164,7 +164,7 @@ export class StalenessDetector {
       const depStatus = supersessionMap.get(depId);
       if (depStatus && depStatus.superseded) {
         reasons.push({
-          signal: 'orphaned-dep',
+          signal: STALE_SIGNAL.ORPHANED_DEP,
           description: `Depends on ${depId} which is superseded by ${depStatus.supersededBy}`,
         });
       }

--- a/src/types/output.ts
+++ b/src/types/output.ts
@@ -30,8 +30,10 @@ export interface FormattableStalenessResult {
   readonly atoms: readonly StaleAtomReport[];
 }
 
+import type { StaleSignal } from '../util/constants.js';
+
 export interface StaleReason {
-  readonly signal: 'age' | 'drift' | 'low-confidence' | 'expired-hint' | 'orphaned-dep';
+  readonly signal: StaleSignal;
   readonly description: string;
 }
 

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -48,6 +48,16 @@ export const DEFAULT_STALE_DRIFT_THRESHOLD = 20;
 export const CONFIG_FILENAME = 'config.toml';
 export const CONFIG_DIR = '.lore';
 
+export const STALE_SIGNAL = {
+  AGE: 'age',
+  DRIFT: 'drift',
+  LOW_CONFIDENCE: 'low-confidence',
+  EXPIRED_HINT: 'expired-hint',
+  ORPHANED_DEP: 'orphaned-dep',
+} as const;
+
+export type StaleSignal = typeof STALE_SIGNAL[keyof typeof STALE_SIGNAL];
+
 export const EXIT_CODE_SUCCESS = 0;
 export const EXIT_CODE_VALIDATION_ERROR = 1;
 export const EXIT_CODE_GIT_ERROR = 2;


### PR DESCRIPTION
## Summary
- Replaces the combinatorial if/else filter logic with a simple data-driven approach
- Collects active signal names from CLI flags, then filters reports that have at least one matching reason
- Correctly handles any combination of `--older-than`, `--drift`, and `--low-confidence` flags

## Test plan
- [ ] Tests pass: `npm test`
- [ ] Type-check passes: `npm run typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)