### PR TITLE
fix(trace): add --max-depth option to limit BFS traversal depth

### DIFF
--- a/src/commands/trace.ts
+++ b/src/commands/trace.ts
@@ -21,7 +21,8 @@ export function registerTraceCommand(
   program
     .command('trace <lore-id>')
     .description('Follow decision chain from a starting atom')
-    .action(async (loreId: string) => {
+    .option('--max-depth <n>', 'Maximum BFS traversal depth', parseInt, 10)
+    .action(async (loreId: string, options: { maxDepth: number }) => {
       const { atomRepository, getFormatter } = deps;
 
       if (!LORE_ID_PATTERN.test(loreId)) {
@@ -48,6 +49,8 @@ export function registerTraceCommand(
         { atom: rootAtom, depth: 0 },
       ];
 
+      const maxDepth = options.maxDepth;
+
       while (queue.length > 0) {
         const entry = queue.shift()!;
         const currentAtom = entry.atom;
@@ -71,7 +74,8 @@ export function registerTraceCommand(
             });
 
             // Continue BFS if this is a new atom we haven't visited
-            if (!visited.has(refId) && targetAtom) {
+            // and we haven't exceeded the depth limit
+            if (!visited.has(refId) && targetAtom && entry.depth + 1 <= maxDepth) {
               visited.add(refId);
               queue.push({ atom: targetAtom, depth: entry.depth + 1 });
             }


### PR DESCRIPTION
## Summary
- Adds `--max-depth <n>` option to the trace command with a default of 10
- Enforces the depth limit in the BFS loop by not enqueuing nodes beyond the limit
- Prevents unbounded traversal of deep or cyclic decision chains

## Test plan
- [x] Tests pass: `npm test`
- [x] Type-check passes: `npm run typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)