### PR TITLE
fix(atom-repository): parallelize getFilesChanged calls in parseRawCommits

### DIFF
--- a/src/services/atom-repository.ts
+++ b/src/services/atom-repository.ts
@@ -196,10 +196,16 @@ export class AtomRepository {
       loreCommits.push({ raw, trailers });
     }
 
-    // Second pass: batch all getFilesChanged calls in parallel
-    const filesChangedResults = await Promise.all(
-      loreCommits.map(({ raw }) => this.gitClient.getFilesChanged(raw.hash)),
-    );
+    // Second pass: batch getFilesChanged calls with concurrency limit
+    const BATCH_SIZE = 20;
+    const filesChangedResults: (readonly string[])[] = [];
+    for (let i = 0; i < loreCommits.length; i += BATCH_SIZE) {
+      const batch = loreCommits.slice(i, i + BATCH_SIZE);
+      const batchResults = await Promise.all(
+        batch.map(({ raw }) => this.gitClient.getFilesChanged(raw.hash)),
+      );
+      filesChangedResults.push(...batchResults);
+    }
 
     // Build atoms from paired data
     const atoms: LoreAtom[] = loreCommits.map(({ raw, trailers }, index) => ({

--- a/src/services/atom-repository.ts
+++ b/src/services/atom-repository.ts
@@ -2,7 +2,7 @@ import type { IGitClient, RawCommit } from '../interfaces/git-client.js';
 import type { PathQueryOptions } from '../types/query.js';
 import type { LoreAtom, LoreId, LoreTrailers } from '../types/domain.js';
 import type { TrailerParser } from '../services/trailer-parser.js';
-import { LORE_ID_PATTERN, REFERENCE_TRAILER_KEYS } from '../util/constants.js';
+import { LORE_ID_PATTERN, REFERENCE_TRAILER_KEYS, GIT_FILES_CHANGED_BATCH_SIZE } from '../util/constants.js';
 
 /**
  * Retrieves LoreAtoms from git history.
@@ -196,18 +196,18 @@ export class AtomRepository {
       loreCommits.push({ raw, trailers });
     }
 
-    // Second pass: batch getFilesChanged calls with concurrency limit
-    const BATCH_SIZE = 20;
-    const filesChangedResults: (readonly string[])[] = [];
-    for (let i = 0; i < loreCommits.length; i += BATCH_SIZE) {
-      const batch = loreCommits.slice(i, i + BATCH_SIZE);
+    // Second pass: batch getFilesChanged calls with concurrency limit.
+    // Results accumulate in insertion order, maintaining 1:1 alignment with loreCommits.
+    const filesPerCommit: (readonly string[])[] = [];
+    for (let i = 0; i < loreCommits.length; i += GIT_FILES_CHANGED_BATCH_SIZE) {
+      const batch = loreCommits.slice(i, i + GIT_FILES_CHANGED_BATCH_SIZE);
       const batchResults = await Promise.all(
         batch.map(({ raw }) => this.gitClient.getFilesChanged(raw.hash)),
       );
-      filesChangedResults.push(...batchResults);
+      filesPerCommit.push(...batchResults);
     }
 
-    // Build atoms from paired data
+    // Build atoms by pairing parsed trailers with their file lists
     const atoms: LoreAtom[] = loreCommits.map(({ raw, trailers }, index) => ({
       loreId: trailers['Lore-id'],
       commitHash: raw.hash,
@@ -216,7 +216,7 @@ export class AtomRepository {
       intent: raw.subject,
       body: this.stripTrailersFromBody(raw.body, raw.trailers),
       trailers,
-      filesChanged: filesChangedResults[index],
+      filesChanged: filesPerCommit[index],
     }));
 
     return atoms;

--- a/src/services/atom-repository.ts
+++ b/src/services/atom-repository.ts
@@ -208,7 +208,20 @@ export class AtomRepository {
     }
 
     // Build atoms by pairing parsed trailers with their file lists
-    const atoms: LoreAtom[] = loreCommits.map(({ raw, trailers }, index) => ({
+    const atoms: LoreAtom[] = loreCommits.map(({ raw, trailers }, index) =>
+      this.buildAtom(raw, trailers, filesPerCommit[index]),
+    );
+
+    return atoms;
+  }
+
+  /**
+   * Construct a LoreAtom from its constituent parts.
+   * Single source of truth for RawCommit -> LoreAtom mapping.
+   * GRASP: Creator -- AtomRepository owns the data needed to create atoms.
+   */
+  private buildAtom(raw: RawCommit, trailers: LoreTrailers, filesChanged: readonly string[]): LoreAtom {
+    return {
       loreId: trailers['Lore-id'],
       commitHash: raw.hash,
       date: new Date(raw.date),
@@ -216,10 +229,8 @@ export class AtomRepository {
       intent: raw.subject,
       body: this.stripTrailersFromBody(raw.body, raw.trailers),
       trailers,
-      filesChanged: filesPerCommit[index],
-    }));
-
-    return atoms;
+      filesChanged,
+    };
   }
 
   /**

--- a/src/services/atom-repository.ts
+++ b/src/services/atom-repository.ts
@@ -180,7 +180,8 @@ export class AtomRepository {
    * Parse an array of RawCommit into LoreAtom[], filtering out non-Lore commits.
    */
   private async parseRawCommits(rawCommits: readonly RawCommit[]): Promise<LoreAtom[]> {
-    const atoms: LoreAtom[] = [];
+    // First pass: filter to Lore commits and parse trailers (synchronous work)
+    const loreCommits: Array<{ raw: RawCommit; trailers: LoreTrailers }> = [];
 
     for (const raw of rawCommits) {
       if (!this.trailerParser.containsLoreTrailers(raw.trailers)) {
@@ -192,21 +193,25 @@ export class AtomRepository {
         continue;
       }
 
-      const filesChanged = await this.gitClient.getFilesChanged(raw.hash);
-
-      const atom: LoreAtom = {
-        loreId: trailers['Lore-id'],
-        commitHash: raw.hash,
-        date: new Date(raw.date),
-        author: raw.author,
-        intent: raw.subject,
-        body: this.stripTrailersFromBody(raw.body, raw.trailers),
-        trailers,
-        filesChanged,
-      };
-
-      atoms.push(atom);
+      loreCommits.push({ raw, trailers });
     }
+
+    // Second pass: batch all getFilesChanged calls in parallel
+    const filesChangedResults = await Promise.all(
+      loreCommits.map(({ raw }) => this.gitClient.getFilesChanged(raw.hash)),
+    );
+
+    // Build atoms from paired data
+    const atoms: LoreAtom[] = loreCommits.map(({ raw, trailers }, index) => ({
+      loreId: trailers['Lore-id'],
+      commitHash: raw.hash,
+      date: new Date(raw.date),
+      author: raw.author,
+      intent: raw.subject,
+      body: this.stripTrailersFromBody(raw.body, raw.trailers),
+      trailers,
+      filesChanged: filesChangedResults[index],
+    }));
 
     return atoms;
   }

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -44,6 +44,7 @@ export const REFERENCE_TRAILER_KEYS = ['Supersedes', 'Depends-on', 'Related'] as
 export const DEFAULT_QUERY_LIMIT = 100;
 export const DEFAULT_STALE_OLDER_THAN = '6m';
 export const DEFAULT_STALE_DRIFT_THRESHOLD = 20;
+export const GIT_FILES_CHANGED_BATCH_SIZE = 20;
 
 export const CONFIG_FILENAME = 'config.toml';
 export const CONFIG_DIR = '.lore';

--- a/tests/unit/services/atom-repository.test.ts
+++ b/tests/unit/services/atom-repository.test.ts
@@ -601,4 +601,48 @@ describe('AtomRepository', () => {
       expect(logArgs).toContain('src/auth.ts');
     });
   });
+
+  describe('batching behavior', () => {
+    it('should call getFilesChanged only for Lore commits, not non-Lore commits', async () => {
+      const loreCommit = makeLoreCommit({ loreId: 'aaaa1111' });
+      const nonLoreCommit: RawCommit = {
+        hash: 'non-lore',
+        date: '2025-01-16T10:00:00Z',
+        author: 'dev@example.com',
+        subject: 'chore: deps',
+        body: '',
+        trailers: '',
+      };
+      vi.mocked(gitClient.log).mockResolvedValue([loreCommit, nonLoreCommit]);
+      vi.mocked(gitClient.getFilesChanged).mockResolvedValue(['src/auth.ts']);
+
+      await repo.findByTarget(makeGitLogArgs(), makeQueryOptions());
+
+      expect(gitClient.getFilesChanged).toHaveBeenCalledTimes(1);
+      expect(gitClient.getFilesChanged).toHaveBeenCalledWith('abc12345');
+    });
+
+    it('should handle more commits than batch size', async () => {
+      const commits = Array.from({ length: 25 }, (_, i) =>
+        makeLoreCommit({ hash: `hash${i}`, loreId: `${String(i).padStart(8, '0')}` }),
+      );
+      vi.mocked(gitClient.log).mockResolvedValue(commits);
+      vi.mocked(gitClient.getFilesChanged).mockResolvedValue(['file.ts']);
+
+      const result = await repo.findByTarget(makeGitLogArgs(), makeQueryOptions());
+
+      expect(result).toHaveLength(25);
+      expect(gitClient.getFilesChanged).toHaveBeenCalledTimes(25);
+    });
+
+    it('should propagate getFilesChanged errors', async () => {
+      const commit = makeLoreCommit({ loreId: 'deadbeef' });
+      vi.mocked(gitClient.log).mockResolvedValue([commit]);
+      vi.mocked(gitClient.getFilesChanged).mockRejectedValue(new Error('git failed'));
+
+      await expect(
+        repo.findByTarget(makeGitLogArgs(), makeQueryOptions()),
+      ).rejects.toThrow('git failed');
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Replaces the sequential `await this.gitClient.getFilesChanged()` in a for-loop with a two-pass approach
- First pass: filter to Lore commits and parse trailers (synchronous)
- Second pass: batch all `getFilesChanged()` calls via `Promise.all()` for parallel git subprocess execution

## Test plan
- [ ] Tests pass: `npm test`
- [ ] Type-check passes: `npm run typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)