### PR TITLE
Add lore coverage as alias for lore tested

### DIFF
--- a/src/commands/tested.ts
+++ b/src/commands/tested.ts
@@ -2,20 +2,27 @@ import type { Command } from 'commander';
 import { executePathQuery, addPathQueryOptions, type PathQueryDeps, type PathQueryCommandOptions } from './helpers/path-query.js';
 
 /**
- * Register the `lore tested <target>` command.
- * Shows Tested and Not-tested trailers.
+ * Register the `lore tested <target>` and `lore coverage <target>` commands.
+ * Both show Tested and Not-tested trailers.
+ * `coverage` is an alias matching the paper's CLI interface (Figure 2).
  */
 export function registerTestedCommand(
   program: Command,
   deps: PathQueryDeps,
 ): void {
-  const cmd = program
+  const action = async (target: string, options: PathQueryCommandOptions) => {
+    await executePathQuery(target, options, deps, 'tested', ['Tested', 'Not-tested']);
+  };
+
+  const tested = program
     .command('tested <target>')
     .description('Test coverage: what was and was not verified');
+  addPathQueryOptions(tested);
+  tested.action(action);
 
-  addPathQueryOptions(cmd);
-
-  cmd.action(async (target: string, options: PathQueryCommandOptions) => {
-    await executePathQuery(target, options, deps, 'tested', ['Tested', 'Not-tested']);
-  });
+  const coverage = program
+    .command('coverage <target>')
+    .description('Test coverage map (alias for tested)');
+  addPathQueryOptions(coverage);
+  coverage.action(action);
 }


### PR DESCRIPTION
## Summary
- Adds `lore coverage <target>` as an alias for `lore tested <target>`
- Matches the paper's CLI interface (Figure 2: `lore coverage <path>`)
- Both commands share the same action handler and options

## Test plan
- [x] `lore coverage --help` shows correct options
- [x] 331 tests pass
- [x] Type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)