### PR TITLE
Fix: coerce single string to array for array trailers in JSON input

### DIFF
--- a/src/example.ts
+++ b/src/example.ts
@@ -1,0 +1,1 @@
+// example module

--- a/src/example.ts
+++ b/src/example.ts
@@ -1,1 +1,1 @@
-// example module
+// updated example

--- a/src/example.ts
+++ b/src/example.ts
@@ -1,1 +1,0 @@
-// updated example

--- a/src/services/readers/json-input-reader.ts
+++ b/src/services/readers/json-input-reader.ts
@@ -52,6 +52,9 @@ export class JsonInputReader implements ICommitInputReader {
     if (Array.isArray(value)) {
       return value.filter((v): v is string => typeof v === 'string');
     }
+    if (typeof value === 'string') {
+      return [value];
+    }
     return undefined;
   }
 

--- a/tests/unit/services/readers/json-input-reader.test.ts
+++ b/tests/unit/services/readers/json-input-reader.test.ts
@@ -108,11 +108,27 @@ describe('JsonInputReader', () => {
       expect(result.trailers?.Constraint).toEqual(['valid', 'also valid']);
     });
 
-    it('should return undefined for non-array trailer values', async () => {
+    it('should coerce a single string trailer value to an array', async () => {
       const input = {
         intent: 'test',
         trailers: {
-          Constraint: 'not an array',
+          Constraint: 'single constraint',
+          Directive: '[until:2026-06] Remove before release',
+        },
+      };
+
+      const reader = new JsonInputReader(JSON.stringify(input));
+      const result = await reader.read();
+
+      expect(result.trailers?.Constraint).toEqual(['single constraint']);
+      expect(result.trailers?.Directive).toEqual(['[until:2026-06] Remove before release']);
+    });
+
+    it('should return undefined for non-string non-array trailer values', async () => {
+      const input = {
+        intent: 'test',
+        trailers: {
+          Constraint: 42,
         },
       };
 


### PR DESCRIPTION
## Summary
- When a JSON input passes an array trailer as a string (`"Directive": "value"`) instead of an array (`"Directive": ["value"]`), the value was silently dropped
- Now coerces single strings to `[string]` automatically
- Found during end-to-end testing

## Test plan
- [x] New test: single string coerced to array
- [x] New test: non-string non-array returns undefined
- [x] 332 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)