### PR TITLE
Add universal agent skill files for AI coding agents

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "files": [
     "bin/",
     "dist/",
-    "schemas/"
+    "schemas/",
+    "skills/"
   ],
   "engines": {
     "node": ">=18.0.0"

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,56 @@
+# Agent Skill Files
+
+Pre-built instruction files that teach AI coding agents to use the Lore protocol. Copy the right file into your project and your agent will automatically query Lore before modifying code and write Lore-enriched commits.
+
+## Quick Setup
+
+Pick your agent, copy one file:
+
+| Agent | Source File | Destination in Your Project |
+|-------|-------------|----------------------------|
+| **Claude Code** | `adapters/claude-code.md` | Append to your `CLAUDE.md` |
+| **Cursor** | `adapters/cursor.mdc` | `.cursor/rules/lore.mdc` |
+| **GitHub Copilot** | `adapters/github-copilot.md` | `.github/copilot-instructions.md` (append if exists) |
+| **Windsurf** | `adapters/windsurf.md` | `.windsurfrules` (append if exists) |
+| **Aider** | `adapters/aider.md` | `.aider/lore-instructions.md` + add to `.aider.conf.yml` |
+| **Any other agent** | `adapters/generic.md` | Paste into system prompt or instruction file |
+
+## What Each File Does
+
+Every adapter tells the agent:
+
+1. **Query before modifying** -- run `lore constraints`, `lore rejected`, and `lore directives` for files being changed
+2. **Respect what it finds** -- constraints are inviolable, rejected approaches are off-limits, directives are standing orders
+3. **Commit with Lore** -- pipe JSON to `lore commit` with the right trailers
+4. **The JSON schema** -- exact format for `lore commit` stdin input
+
+## Universal Reference
+
+`lore-agent-instructions.md` is the comprehensive reference document. It covers everything an agent needs to know about Lore in detail. Use it if:
+
+- You want to understand the full protocol before picking an adapter
+- Your agent platform is not listed above
+- You want to build your own custom adapter
+
+The platform adapters are streamlined versions of this document, formatted for each platform's conventions.
+
+## Example: Claude Code
+
+```sh
+# From your project root (assuming lore-cli is installed globally)
+cat /path/to/lore-cli/skills/adapters/claude-code.md >> CLAUDE.md
+```
+
+## Example: Cursor
+
+```sh
+mkdir -p .cursor/rules
+cp /path/to/lore-cli/skills/adapters/cursor.mdc .cursor/rules/lore.mdc
+```
+
+## Example: GitHub Copilot
+
+```sh
+mkdir -p .github
+cat /path/to/lore-cli/skills/adapters/github-copilot.md >> .github/copilot-instructions.md
+```

--- a/skills/adapters/aider.md
+++ b/skills/adapters/aider.md
@@ -1,0 +1,73 @@
+# Lore Protocol Integration
+
+This project uses the **Lore protocol** (v1.0) to embed structured decision context into git commits. Before modifying code, query Lore. When committing, write Lore.
+
+## Before Modifying Any File
+
+Run these shell commands for every file you are about to change:
+
+```sh
+lore constraints <path> --json
+lore rejected <path> --json
+lore directives <path> --json
+```
+
+**Constraint** = hard requirement, do not violate. **Rejected** = approach tried and abandoned (`alternative | reason`), do not re-explore. **Directive** = standing instruction, follow it.
+
+## When Committing
+
+Aider manages its own commits. When you produce a commit message, format it as a Lore-enriched message. Alternatively, after Aider commits, run a Lore commit separately:
+
+```sh
+echo '{
+  "intent": "fix: handle null user in auth middleware",
+  "body": "Previously threw 500 on null user. Now returns 401.",
+  "trailers": {
+    "Constraint": ["must not throw -- return 401 instead"],
+    "Rejected": ["silent redirect to login | breaks API clients"],
+    "Confidence": "high",
+    "Scope-risk": "narrow",
+    "Tested": ["null user returns 401", "valid user still works"],
+    "Not-tested": ["concurrent request race condition"]
+  }
+}' | lore commit
+```
+
+### JSON Schema
+
+- `intent` (string, REQUIRED): why the change was made, max 72 chars
+- `body` (string, optional): narrative context
+- `trailers` (object, optional):
+  - `Constraint`: string[] -- hard requirements
+  - `Rejected`: string[] -- format `alternative | reason`
+  - `Confidence`: `"low"` | `"medium"` | `"high"`
+  - `Scope-risk`: `"narrow"` | `"moderate"` | `"wide"`
+  - `Reversibility`: `"clean"` | `"migration-needed"` | `"irreversible"`
+  - `Directive`: string[] -- future instructions
+  - `Tested`: string[] -- verified scenarios
+  - `Not-tested`: string[] -- known gaps
+  - `Supersedes`: string[] -- 8-char hex Lore-ids replaced
+  - `Depends-on`: string[] -- 8-char hex Lore-ids required
+  - `Related`: string[] -- 8-char hex Lore-ids for reference
+
+Only `intent` is required. Include only relevant trailers. `Lore-id` is auto-generated.
+
+## Integration with Aider Configuration
+
+Add this to your `.aider.conf.yml` to load Lore instructions:
+
+```yaml
+read:
+  - .aider/lore-instructions.md
+```
+
+Then place this file at `.aider/lore-instructions.md` in your project.
+
+## Other Commands
+
+```sh
+lore context <path> --json     # Full context
+lore why <file>:<line> --json  # Line-level blame
+lore search --text "q" --json  # Search all lore
+lore stale <path> --json       # Outdated decisions
+```

--- a/skills/adapters/claude-code.md
+++ b/skills/adapters/claude-code.md
@@ -1,0 +1,82 @@
+# Lore Protocol Integration
+
+This project uses the **Lore protocol** (v1.0) to embed structured decision context into git commits. Lore trailers record constraints, rejected alternatives, and directives alongside code changes. You MUST query Lore before modifying files and write Lore-enriched commits.
+
+## Before Modifying Any File
+
+Query the Lore context for every file or directory you are about to change:
+
+```sh
+lore constraints <path> --json
+lore rejected <path> --json
+lore directives <path> --json
+```
+
+**Rules:**
+- **Constraint** = hard requirement. Do not write code that violates it.
+- **Rejected** = approach already tried and abandoned (`alternative | reason`). Do not re-explore it.
+- **Directive** = standing instruction. Follow it.
+
+If `lore constraints` returns results for a file, verify your planned changes comply before writing code. If `lore rejected` matches your intended approach, choose a different one.
+
+## When Committing
+
+Stage changes with `git add`, then pipe JSON to `lore commit`:
+
+```sh
+echo '{
+  "intent": "fix: handle null user in auth middleware",
+  "body": "Previously threw 500 on null user. Now returns 401.",
+  "trailers": {
+    "Constraint": ["must not throw -- return 401 instead"],
+    "Rejected": ["silent redirect to login | breaks API clients"],
+    "Confidence": "high",
+    "Scope-risk": "narrow",
+    "Tested": ["null user returns 401", "valid user still works"],
+    "Not-tested": ["concurrent request race condition"]
+  }
+}' | lore commit
+```
+
+### JSON Schema
+
+```json
+{
+  "intent": "string (REQUIRED) -- why the change was made, max 72 chars",
+  "body": "string (optional) -- narrative context",
+  "trailers": {
+    "Constraint": ["string array -- hard requirements that must hold"],
+    "Rejected": ["string array -- format: 'alternative | reason'"],
+    "Confidence": "enum: 'low' | 'medium' | 'high'",
+    "Scope-risk": "enum: 'narrow' | 'moderate' | 'wide'",
+    "Reversibility": "enum: 'clean' | 'migration-needed' | 'irreversible'",
+    "Directive": ["string array -- instructions for future maintainers"],
+    "Tested": ["string array -- what was verified"],
+    "Not-tested": ["string array -- known untested areas"],
+    "Supersedes": ["8-char hex Lore-id array -- decisions this replaces"],
+    "Depends-on": ["8-char hex Lore-id array -- decisions this requires"],
+    "Related": ["8-char hex Lore-id array -- informational links"]
+  }
+}
+```
+
+Only `intent` is required. Include only relevant trailers -- do not pad with empty values. `Lore-id` is auto-generated.
+
+### When to Add Trailers
+
+- You chose approach A over B: add `Rejected`
+- A rule must hold going forward: add `Constraint`
+- Future developers need an instruction: add `Directive`
+- You are unsure: set `Confidence` to `"low"` or `"medium"`
+- Change is hard to undo: set `Reversibility`
+- You left something untested: add `Not-tested`
+
+## Other Commands
+
+```sh
+lore context <path> --json     # Full context for a file/directory
+lore why <file>:<line> --json  # Line-level blame with Lore context
+lore search --text "q" --json  # Search across all lore
+lore stale <path> --json       # Check for outdated decisions
+lore trace <lore-id> --json    # Trace a decision chain
+```

--- a/skills/adapters/cursor.mdc
+++ b/skills/adapters/cursor.mdc
@@ -1,0 +1,78 @@
+---
+description: Lore protocol integration -- query decision context before modifying files, write enriched commits
+globs:
+alwaysApply: true
+---
+
+# Lore Protocol
+
+This project uses the **Lore protocol** (v1.0) to embed structured decision context into git commits. Constraints, rejected alternatives, and directives are stored as git trailers and queryable via the `lore` CLI.
+
+## Before Modifying Any File
+
+Run these commands for every file or directory you are about to change:
+
+```sh
+lore constraints <path> --json
+lore rejected <path> --json
+lore directives <path> --json
+```
+
+**Rules:**
+- **Constraint** = hard requirement. Do not write code that violates it.
+- **Rejected** = approach already tried and abandoned (`alternative | reason`). Do not re-explore it.
+- **Directive** = standing instruction. Follow it.
+
+## When Committing
+
+Stage changes with `git add`, then pipe JSON to `lore commit`:
+
+```sh
+echo '{
+  "intent": "fix: handle null user in auth middleware",
+  "body": "Previously threw 500 on null user. Now returns 401.",
+  "trailers": {
+    "Constraint": ["must not throw -- return 401 instead"],
+    "Rejected": ["silent redirect to login | breaks API clients"],
+    "Confidence": "high",
+    "Scope-risk": "narrow",
+    "Tested": ["null user returns 401", "valid user still works"],
+    "Not-tested": ["concurrent request race condition"]
+  }
+}' | lore commit
+```
+
+### JSON Schema
+
+- `intent` (string, REQUIRED): why the change was made, max 72 chars
+- `body` (string, optional): narrative context
+- `trailers` (object, optional):
+  - `Constraint`: string array -- hard requirements
+  - `Rejected`: string array -- format `alternative | reason`
+  - `Confidence`: `low` | `medium` | `high`
+  - `Scope-risk`: `narrow` | `moderate` | `wide`
+  - `Reversibility`: `clean` | `migration-needed` | `irreversible`
+  - `Directive`: string array -- future instructions
+  - `Tested`: string array -- verified scenarios
+  - `Not-tested`: string array -- known gaps
+  - `Supersedes`: string array -- 8-char hex Lore-ids replaced
+  - `Depends-on`: string array -- 8-char hex Lore-ids required
+  - `Related`: string array -- 8-char hex Lore-ids for reference
+
+Only include relevant trailers. `Lore-id` is auto-generated.
+
+### When to Add Trailers
+
+- Chose approach A over B: `Rejected: ["B | reason"]`
+- Rule must hold: `Constraint: ["the rule"]`
+- Instruction for future: `Directive: ["the instruction"]`
+- Unsure: `Confidence: "low"`
+- Hard to undo: `Reversibility: "migration-needed"`
+- Left untested: `Not-tested: ["the gap"]`
+
+## Other Commands
+
+- `lore context <path> --json` -- full context
+- `lore why <file>:<line> --json` -- line-level blame
+- `lore search --text "query" --json` -- search all lore
+- `lore stale <path> --json` -- outdated decisions

--- a/skills/adapters/generic.md
+++ b/skills/adapters/generic.md
@@ -1,0 +1,89 @@
+# Lore Protocol -- Agent Instructions
+
+Copy this into your AI agent's system prompt or instruction file.
+
+---
+
+## What Is Lore
+
+Lore embeds structured decision context (constraints, rejected alternatives, directives) into git commit trailers. It is queryable via the `lore` CLI. Protocol version: 1.0.
+
+## Before Modifying Any File
+
+Run these commands for every file or directory you are about to change:
+
+```sh
+lore constraints <path> --json
+lore rejected <path> --json
+lore directives <path> --json
+```
+
+- **Constraint** = hard requirement. Do not violate.
+- **Rejected** = approach tried and abandoned (`alternative | reason`). Do not re-explore.
+- **Directive** = standing instruction. Follow it.
+
+If constraints exist, verify your changes comply. If a rejected alternative matches your plan, choose differently.
+
+## When Committing
+
+Stage changes with `git add`, then pipe JSON to `lore commit`:
+
+```sh
+echo '{
+  "intent": "fix: handle null user in auth middleware",
+  "body": "Previously threw 500 on null user. Now returns 401.",
+  "trailers": {
+    "Constraint": ["must not throw -- return 401 instead"],
+    "Rejected": ["silent redirect to login | breaks API clients"],
+    "Confidence": "high",
+    "Scope-risk": "narrow",
+    "Tested": ["null user returns 401", "valid user still works"],
+    "Not-tested": ["concurrent request race condition"]
+  }
+}' | lore commit
+```
+
+### JSON Schema
+
+```json
+{
+  "intent": "string (REQUIRED) -- max 72 chars",
+  "body": "string (optional)",
+  "trailers": {
+    "Constraint": ["string array"],
+    "Rejected": ["format: 'alternative | reason'"],
+    "Confidence": "'low' | 'medium' | 'high'",
+    "Scope-risk": "'narrow' | 'moderate' | 'wide'",
+    "Reversibility": "'clean' | 'migration-needed' | 'irreversible'",
+    "Directive": ["string array"],
+    "Tested": ["string array"],
+    "Not-tested": ["string array"],
+    "Supersedes": ["8-char hex Lore-id"],
+    "Depends-on": ["8-char hex Lore-id"],
+    "Related": ["8-char hex Lore-id"]
+  }
+}
+```
+
+Only `intent` is required. `Lore-id` is auto-generated.
+
+### When to Add Trailers
+
+| Situation | Trailer |
+|-----------|---------|
+| Chose A over B | `Rejected: ["B \| reason"]` |
+| Rule must hold | `Constraint: ["the rule"]` |
+| Future instruction | `Directive: ["the instruction"]` |
+| Unsure | `Confidence: "low"` |
+| Hard to undo | `Reversibility: "migration-needed"` |
+| Known gap | `Not-tested: ["the gap"]` |
+
+## Other Commands
+
+| Command | Purpose |
+|---------|---------|
+| `lore context <path> --json` | Full context for a file/directory |
+| `lore why <file>:<line> --json` | Line-level blame with Lore context |
+| `lore search --text "q" --json` | Search across all lore |
+| `lore stale <path> --json` | Check for outdated decisions |
+| `lore trace <lore-id> --json` | Trace a decision chain |

--- a/skills/adapters/github-copilot.md
+++ b/skills/adapters/github-copilot.md
@@ -1,0 +1,77 @@
+# Lore Protocol Integration
+
+This project uses the **Lore protocol** (v1.0) to embed structured decision context into git commits. Constraints, rejected alternatives, and directives are stored as git trailers and queryable via the `lore` CLI.
+
+## Before Modifying Any File
+
+Run these commands in the terminal for every file or directory you are about to change:
+
+```sh
+lore constraints <path> --json
+lore rejected <path> --json
+lore directives <path> --json
+```
+
+**Rules:**
+- **Constraint** = hard requirement. Do not write code that violates it.
+- **Rejected** = approach already tried and abandoned (`alternative | reason`). Do not re-explore it.
+- **Directive** = standing instruction from a past decision. Follow it.
+
+If constraints exist for a file, verify your changes comply before writing code. If a rejected alternative matches your intended approach, choose a different one.
+
+## When Committing
+
+Stage changes with `git add`, then pipe JSON to `lore commit`:
+
+```sh
+echo '{
+  "intent": "fix: handle null user in auth middleware",
+  "body": "Previously threw 500 on null user. Now returns 401.",
+  "trailers": {
+    "Constraint": ["must not throw -- return 401 instead"],
+    "Rejected": ["silent redirect to login | breaks API clients"],
+    "Confidence": "high",
+    "Scope-risk": "narrow",
+    "Tested": ["null user returns 401", "valid user still works"],
+    "Not-tested": ["concurrent request race condition"]
+  }
+}' | lore commit
+```
+
+### JSON Schema
+
+- `intent` (string, REQUIRED): why the change was made, max 72 chars
+- `body` (string, optional): narrative context
+- `trailers` (object, optional):
+  - `Constraint`: string[] -- hard requirements that must hold
+  - `Rejected`: string[] -- format `alternative | reason`
+  - `Confidence`: `"low"` | `"medium"` | `"high"`
+  - `Scope-risk`: `"narrow"` | `"moderate"` | `"wide"`
+  - `Reversibility`: `"clean"` | `"migration-needed"` | `"irreversible"`
+  - `Directive`: string[] -- instructions for future maintainers
+  - `Tested`: string[] -- what was verified
+  - `Not-tested`: string[] -- known untested areas
+  - `Supersedes`: string[] -- 8-char hex Lore-ids this replaces
+  - `Depends-on`: string[] -- 8-char hex Lore-ids this requires
+  - `Related`: string[] -- 8-char hex Lore-ids for reference
+
+Only `intent` is required. Include only relevant trailers. `Lore-id` is auto-generated.
+
+### When to Add Trailers
+
+- You chose approach A over B: `Rejected: ["B | reason"]`
+- A rule must hold going forward: `Constraint: ["the rule"]`
+- Future developers need an instruction: `Directive: ["the instruction"]`
+- You are unsure this is right: `Confidence: "low"` or `"medium"`
+- Change is hard to undo: `Reversibility: "migration-needed"` or `"irreversible"`
+- You left something untested: `Not-tested: ["the gap"]`
+
+## Other Commands
+
+```sh
+lore context <path> --json     # Full context for a file/directory
+lore why <file>:<line> --json  # Line-level blame with Lore context
+lore search --text "q" --json  # Search across all lore
+lore stale <path> --json       # Check for outdated decisions
+lore trace <lore-id> --json    # Trace a decision chain
+```

--- a/skills/adapters/windsurf.md
+++ b/skills/adapters/windsurf.md
@@ -1,0 +1,74 @@
+# Lore Protocol Integration
+
+This project uses the **Lore protocol** (v1.0) to embed structured decision context into git commits. Constraints, rejected alternatives, and directives are stored as git trailers and queryable via the `lore` CLI.
+
+## Before Modifying Any File
+
+Run these commands for every file or directory you are about to change:
+
+```sh
+lore constraints <path> --json
+lore rejected <path> --json
+lore directives <path> --json
+```
+
+**Rules:**
+- **Constraint** = hard requirement. Do not write code that violates it.
+- **Rejected** = approach already tried and abandoned (`alternative | reason`). Do not re-explore it.
+- **Directive** = standing instruction. Follow it.
+
+## When Committing
+
+Stage changes with `git add`, then pipe JSON to `lore commit`:
+
+```sh
+echo '{
+  "intent": "fix: handle null user in auth middleware",
+  "body": "Previously threw 500 on null user. Now returns 401.",
+  "trailers": {
+    "Constraint": ["must not throw -- return 401 instead"],
+    "Rejected": ["silent redirect to login | breaks API clients"],
+    "Confidence": "high",
+    "Scope-risk": "narrow",
+    "Tested": ["null user returns 401", "valid user still works"],
+    "Not-tested": ["concurrent request race condition"]
+  }
+}' | lore commit
+```
+
+### JSON Schema
+
+- `intent` (string, REQUIRED): why the change was made, max 72 chars
+- `body` (string, optional): narrative context
+- `trailers` (object, optional):
+  - `Constraint`: string[] -- hard requirements
+  - `Rejected`: string[] -- format `alternative | reason`
+  - `Confidence`: `"low"` | `"medium"` | `"high"`
+  - `Scope-risk`: `"narrow"` | `"moderate"` | `"wide"`
+  - `Reversibility`: `"clean"` | `"migration-needed"` | `"irreversible"`
+  - `Directive`: string[] -- future instructions
+  - `Tested`: string[] -- verified scenarios
+  - `Not-tested`: string[] -- known gaps
+  - `Supersedes`: string[] -- 8-char hex Lore-ids replaced
+  - `Depends-on`: string[] -- 8-char hex Lore-ids required
+  - `Related`: string[] -- 8-char hex Lore-ids for reference
+
+Only `intent` is required. Include only relevant trailers. `Lore-id` is auto-generated.
+
+### When to Add Trailers
+
+- Chose approach A over B: `Rejected: ["B | reason"]`
+- Rule must hold: `Constraint: ["the rule"]`
+- Instruction for future: `Directive: ["the instruction"]`
+- Unsure: `Confidence: "low"`
+- Hard to undo: `Reversibility: "migration-needed"`
+- Left untested: `Not-tested: ["the gap"]`
+
+## Other Commands
+
+```sh
+lore context <path> --json     # Full context
+lore why <file>:<line> --json  # Line-level blame
+lore search --text "q" --json  # Search all lore
+lore stale <path> --json       # Outdated decisions
+```

--- a/skills/lore-agent-instructions.md
+++ b/skills/lore-agent-instructions.md
@@ -1,0 +1,192 @@
+# Lore Protocol -- Agent Instructions
+
+Lore embeds structured decision context (constraints, rejected alternatives, directives) into git commit trailers. Before modifying code, query Lore. When committing, write Lore.
+
+**Protocol version:** 1.0
+
+---
+
+## 1. Before Modifying Code
+
+Before changing any file, query Lore for that file or directory. This prevents you from repeating rejected approaches, violating constraints, or undoing intentional decisions.
+
+### Commands to Run
+
+```sh
+# What constraints must I respect?
+lore constraints <path> --json
+
+# What approaches were already tried and rejected?
+lore rejected <path> --json
+
+# What forward-looking instructions exist?
+lore directives <path> --json
+
+# Full context (all of the above plus confidence, test notes, references)
+lore context <path> --json
+```
+
+`<path>` is the file or directory you are about to modify. Use `--json` for structured output.
+
+### How to Interpret Results
+
+| Trailer | What It Means | What You Must Do |
+|---------|---------------|------------------|
+| **Constraint** | A hard requirement that must hold. Violations are bugs. | **Obey it.** Do not write code that violates a constraint. |
+| **Rejected** | An approach that was tried and deliberately abandoned. Format: `alternative \| reason`. | **Do not re-explore it** unless circumstances have explicitly changed. |
+| **Directive** | A forward-looking instruction from a past decision-maker. | **Follow it.** Treat as a standing order. |
+| **Confidence** | How confident the author was (`low`, `medium`, `high`). | Low confidence = the decision may be worth revisiting. High = leave it alone unless you have strong reason. |
+| **Scope-risk** | Blast radius (`narrow`, `moderate`, `wide`). | Wide scope-risk = be extra careful, test thoroughly. |
+| **Reversibility** | How hard to undo (`clean`, `migration-needed`, `irreversible`). | Irreversible = do not change without explicit user approval. |
+| **Not-tested** | Known gaps in test coverage. | Be aware these areas may break silently. |
+| **Supersedes** | This atom replaced a previous decision (by Lore-id). | The superseded decision is obsolete -- ignore it. |
+
+### Query Workflow
+
+1. Identify the files you will modify.
+2. Run `lore constraints <path> --json` and `lore rejected <path> --json` for each.
+3. If any constraints apply, verify your planned changes respect them.
+4. If any rejected alternatives match what you were about to do, stop and choose a different approach.
+5. Run `lore directives <path> --json` and follow any instructions found.
+
+---
+
+## 2. When Committing Code
+
+After making changes, create a Lore-enriched commit by piping JSON to `lore commit`.
+
+### JSON Schema
+
+```json
+{
+  "intent": "string (REQUIRED) -- why the change was made, max 72 chars",
+  "body": "string (optional) -- narrative context, multiple lines allowed",
+  "trailers": {
+    "Constraint": ["string array -- hard requirements that must hold"],
+    "Rejected": ["string array -- format: 'alternative | reason'"],
+    "Confidence": "enum: 'low' | 'medium' | 'high'",
+    "Scope-risk": "enum: 'narrow' | 'moderate' | 'wide'",
+    "Reversibility": "enum: 'clean' | 'migration-needed' | 'irreversible'",
+    "Directive": ["string array -- instructions for future maintainers"],
+    "Tested": ["string array -- what was verified"],
+    "Not-tested": ["string array -- known untested areas"],
+    "Supersedes": ["string array -- 8-char hex Lore-ids this replaces"],
+    "Depends-on": ["string array -- 8-char hex Lore-ids this requires"],
+    "Related": ["string array -- 8-char hex Lore-ids for reference"]
+  }
+}
+```
+
+All trailer fields are optional. Only `intent` is required. Include trailers that are relevant -- do not pad with empty values.
+
+### Commit Command
+
+Stage your changes with `git add`, then pipe JSON to `lore commit`:
+
+```sh
+echo '{
+  "intent": "fix: handle null user in auth middleware",
+  "body": "Previously threw 500 on null user. Now returns 401.",
+  "trailers": {
+    "Constraint": ["must not throw -- return 401 instead"],
+    "Rejected": ["silent redirect to login | breaks API clients"],
+    "Confidence": "high",
+    "Scope-risk": "narrow",
+    "Tested": ["null user returns 401", "valid user still works"],
+    "Not-tested": ["concurrent request race condition"]
+  }
+}' | lore commit
+```
+
+A `Lore-id` is generated automatically -- do not include one.
+
+### What to Include in Trailers
+
+| Situation | Trailers to Add |
+|-----------|----------------|
+| You chose approach A over B | `Rejected: ["B \| reason"]` |
+| There is a rule future code must follow | `Constraint: ["the rule"]` |
+| There is something the next developer should know | `Directive: ["the instruction"]` |
+| You are not sure this is the right approach | `Confidence: "low"` or `"medium"` |
+| The change affects many files/systems | `Scope-risk: "wide"` |
+| The change is hard to undo | `Reversibility: "migration-needed"` or `"irreversible"` |
+| You tested specific scenarios | `Tested: ["scenario 1", "scenario 2"]` |
+| You know something is untested | `Not-tested: ["the gap"]` |
+| This replaces a previous decision | `Supersedes: ["<lore-id>"]` |
+
+---
+
+## 3. Other Useful Commands
+
+```sh
+# Why does a specific line exist?
+lore why <file>:<line> --json
+
+# Search across all lore
+lore search --text "keyword" --json
+
+# Check for stale/outdated decisions
+lore stale <path> --json
+
+# Trace a decision chain
+lore trace <lore-id> --json
+
+# Validate recent commits for protocol compliance
+lore validate HEAD~5..HEAD
+```
+
+---
+
+## 4. Example Workflow
+
+**Task:** "Add rate limiting to the /api/upload endpoint"
+
+```sh
+# Step 1: Query before coding
+lore constraints src/routes/upload.ts --json
+lore rejected src/routes/upload.ts --json
+lore directives src/routes/upload.ts --json
+
+# Step 2: Read the results
+# Suppose you find:
+#   Constraint: "file size validation must happen before upload starts"
+#   Rejected: "client-side rate limiting | easily bypassed"
+#   Directive: "all rate limits must be configurable via env vars"
+
+# Step 3: Implement respecting what you found
+# - Keep file size validation before upload (constraint)
+# - Do NOT implement client-side rate limiting (rejected)
+# - Make rate limits configurable via env vars (directive)
+
+# Step 4: Stage and commit with Lore
+git add src/routes/upload.ts src/middleware/rate-limit.ts
+
+echo '{
+  "intent": "feat: add server-side rate limiting to /api/upload",
+  "body": "Adds token-bucket rate limiter as Express middleware. Limits configurable via UPLOAD_RATE_LIMIT and UPLOAD_RATE_WINDOW env vars.",
+  "trailers": {
+    "Constraint": ["rate limit values must come from env vars, not hardcoded"],
+    "Rejected": ["per-IP limiting only | fails behind shared NAT, need auth-based limiting too"],
+    "Confidence": "high",
+    "Scope-risk": "narrow",
+    "Tested": ["rate limit triggers 429 after threshold", "authenticated vs anonymous limits differ"],
+    "Not-tested": ["behavior under Redis connection failure"]
+  }
+}' | lore commit
+```
+
+---
+
+## 5. Quick Reference
+
+| Action | Command |
+|--------|---------|
+| Query constraints | `lore constraints <path> --json` |
+| Query rejected approaches | `lore rejected <path> --json` |
+| Query directives | `lore directives <path> --json` |
+| Full context | `lore context <path> --json` |
+| Line-level blame | `lore why <file>:<line> --json` |
+| Commit with Lore | `echo '<json>' \| lore commit` |
+| Search all lore | `lore search --text "query" --json` |
+| Check staleness | `lore stale <path> --json` |
+| Validate commits | `lore validate <range>` |

--- a/src/example.ts
+++ b/src/example.ts
@@ -1,0 +1,1 @@
+// example module

--- a/src/example.ts
+++ b/src/example.ts
@@ -1,1 +1,1 @@
-// example module
+// updated example

--- a/src/example.ts
+++ b/src/example.ts
@@ -1,1 +1,0 @@
-// updated example


### PR DESCRIPTION
## Summary
- **`skills/lore-agent-instructions.md`** — Universal reference (192 lines): query workflow, trailer semantics table, JSON commit schema, end-to-end example
- **6 platform adapters** — Self-contained, drop-in files for Claude Code, Cursor, GitHub Copilot, Windsurf, Aider, and generic system prompts
- **`skills/README.md`** — Setup guide with copy commands per platform
- Added `skills/` to package.json `files` array so they ship with `npm install`

Each adapter teaches three behavioral rules:
1. **Constraint** = obey (violations are bugs)
2. **Rejected** = do not re-explore (dead ends)
3. **Directive** = follow (standing orders)

## Test plan
- [x] All files are self-contained markdown
- [x] JSON schema matches `CommitInput` type exactly
- [x] 332 tests pass, build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)