### PR TITLE
Add lore metrics command for adoption and health measurement

### DIFF
--- a/src/commands/metrics.ts
+++ b/src/commands/metrics.ts
@@ -1,0 +1,74 @@
+import type { Command } from 'commander';
+import type { AtomRepository } from '../services/atom-repository.js';
+import type { SupersessionResolver } from '../services/supersession-resolver.js';
+import type { StalenessDetector } from '../services/staleness-detector.js';
+import type { IGitClient } from '../interfaces/git-client.js';
+import type { IOutputFormatter } from '../interfaces/output-formatter.js';
+import type { LoreConfig } from '../types/config.js';
+import { MetricsCollector } from '../services/metrics-collector.js';
+
+/**
+ * Register the `lore metrics` command.
+ * Computes 8 categories of adoption and health metrics for a Lore-enriched repository.
+ */
+export function registerMetricsCommand(
+  program: Command,
+  deps: {
+    atomRepository: AtomRepository;
+    supersessionResolver: SupersessionResolver;
+    stalenessDetector: StalenessDetector;
+    gitClient: IGitClient;
+    config: LoreConfig;
+    getFormatter: () => IOutputFormatter;
+  },
+): void {
+  program
+    .command('metrics')
+    .description('Measure Lore adoption and protocol health')
+    .option('--since <ref>', 'Only consider commits since ref/date')
+    .action(async (options: { since?: string }) => {
+      const {
+        atomRepository,
+        supersessionResolver,
+        stalenessDetector,
+        gitClient,
+        getFormatter,
+      } = deps;
+
+      // Resolve the --since option: command-level overrides global
+      const globalOpts = program.opts();
+      const since = options.since ?? globalOpts.since ?? undefined;
+
+      // 1. Fetch all Lore atoms
+      const atoms = await atomRepository.findAll({ since });
+
+      // 2. Count total commits in the repo (within the same period)
+      const totalCommitCount = await gitClient.countAllCommits(since);
+
+      // 3. List all tracked files in the repo
+      const allRepoFiles = await gitClient.listTrackedFiles();
+
+      // 4. Compute supersession
+      const supersessionMap = supersessionResolver.resolve(atoms);
+      const activeAtoms = supersessionResolver.filterActive(atoms, supersessionMap);
+
+      // 5. Run staleness analysis on active atoms
+      const staleReports = await stalenessDetector.analyze(activeAtoms, supersessionMap);
+      const staleAtomIds = new Set(staleReports.map(r => r.atom.loreId));
+
+      // 6. Collect all metrics
+      const metricsCollector = new MetricsCollector();
+      const result = metricsCollector.collectAll({
+        atoms,
+        supersessionMap,
+        staleAtomIds,
+        totalCommitCount,
+        allRepoFiles: [...allRepoFiles],
+        since: since ?? null,
+      });
+
+      // 7. Format and output
+      const formatter = getFormatter();
+      console.log(formatter.formatMetricsResult(result));
+    });
+}

--- a/src/commands/metrics.ts
+++ b/src/commands/metrics.ts
@@ -4,8 +4,7 @@ import type { SupersessionResolver } from '../services/supersession-resolver.js'
 import type { StalenessDetector } from '../services/staleness-detector.js';
 import type { IGitClient } from '../interfaces/git-client.js';
 import type { IOutputFormatter } from '../interfaces/output-formatter.js';
-import type { LoreConfig } from '../types/config.js';
-import { MetricsCollector } from '../services/metrics-collector.js';
+import type { MetricsCollector } from '../services/metrics-collector.js';
 
 /**
  * Register the `lore metrics` command.
@@ -18,7 +17,7 @@ export function registerMetricsCommand(
     supersessionResolver: SupersessionResolver;
     stalenessDetector: StalenessDetector;
     gitClient: IGitClient;
-    config: LoreConfig;
+    metricsCollector: MetricsCollector;
     getFormatter: () => IOutputFormatter;
   },
 ): void {
@@ -32,6 +31,7 @@ export function registerMetricsCommand(
         supersessionResolver,
         stalenessDetector,
         gitClient,
+        metricsCollector,
         getFormatter,
       } = deps;
 
@@ -57,7 +57,6 @@ export function registerMetricsCommand(
       const staleAtomIds = new Set(staleReports.map(r => r.atom.loreId));
 
       // 6. Collect all metrics
-      const metricsCollector = new MetricsCollector();
       const result = metricsCollector.collectAll({
         atoms,
         supersessionMap,

--- a/src/formatters/json-formatter.ts
+++ b/src/formatters/json-formatter.ts
@@ -5,6 +5,7 @@ import type {
   FormattableStalenessResult,
   FormattableTraceResult,
   FormattableDoctorResult,
+  FormattableMetricsResult,
 } from '../types/output.js';
 import type { LoreAtom, LoreTrailers } from '../types/domain.js';
 
@@ -141,6 +142,66 @@ export class JsonFormatter implements IOutputFormatter {
           warnings: data.summary.warnings,
           info: data.summary.info,
         },
+      },
+      null,
+      2,
+    );
+  }
+
+  formatMetricsResult(data: FormattableMetricsResult): string {
+    return JSON.stringify(
+      {
+        lore_version: '1.0',
+        period: {
+          since: data.period.since,
+          analyzed_at: data.period.analyzedAt,
+        },
+        adoption: {
+          total_commits: data.adoption.totalCommits,
+          lore_commits: data.adoption.loreCommits,
+          adoption_rate: data.adoption.adoptionRate,
+        },
+        decision_density: {
+          unique_files_touched: data.decisionDensity.uniqueFilesTouched,
+          files_with_atoms: data.decisionDensity.filesWithAtoms,
+          atoms_per_file: data.decisionDensity.atomsPerFile,
+          blind_spot_files: [...data.decisionDensity.blindSpotFiles],
+          blind_spot_count: data.decisionDensity.blindSpotCount,
+        },
+        trailer_coverage: {
+          total_atoms: data.trailerCoverage.totalAtoms,
+          trailers: data.trailerCoverage.trailers.map((t) => ({
+            trailer: t.trailer,
+            count: t.count,
+            percentage: t.percentage,
+          })),
+        },
+        staleness: {
+          total_active: data.staleness.totalActive,
+          stale_count: data.staleness.staleCount,
+          staleness_rate: data.staleness.stalenessRate,
+        },
+        supersession_depth: {
+          total_chains: data.supersessionDepth.totalChains,
+          average_depth: data.supersessionDepth.averageDepth,
+          max_depth: data.supersessionDepth.maxDepth,
+        },
+        constraint_coverage: {
+          total_repo_files: data.constraintCoverage.totalRepoFiles,
+          files_with_constraint: data.constraintCoverage.filesWithConstraint,
+          coverage_rate: data.constraintCoverage.coverageRate,
+        },
+        rejection_library: {
+          unique_rejections: data.rejectionLibrary.uniqueRejections,
+          total_rejection_entries: data.rejectionLibrary.totalRejectionEntries,
+        },
+        author_breakdown: {
+          agent_commits: data.authorBreakdown.agentCommits,
+          human_commits: data.authorBreakdown.humanCommits,
+          agent_adoption_rate: data.authorBreakdown.agentAdoptionRate,
+          human_adoption_rate: data.authorBreakdown.humanAdoptionRate,
+        },
+        benchmarking_guide: 'Automatic metrics: adoption rate, trailer coverage, staleness rate, constraint spread. Manual metrics to track: re-proposed rejections, review cycles, time-to-correct, onboarding time. Export for tracking: lore metrics --json > metrics-$(date +%Y-%m-%d).json',
       },
       null,
       2,

--- a/src/formatters/json-formatter.ts
+++ b/src/formatters/json-formatter.ts
@@ -196,8 +196,8 @@ export class JsonFormatter implements IOutputFormatter {
           total_rejection_entries: data.rejectionLibrary.totalRejectionEntries,
         },
         author_breakdown: {
-          agent_commits: data.authorBreakdown.agentCommits,
-          human_commits: data.authorBreakdown.humanCommits,
+          agent_lore_commits: data.authorBreakdown.agentLoreCommits,
+          human_lore_commits: data.authorBreakdown.humanLoreCommits,
           agent_adoption_rate: data.authorBreakdown.agentAdoptionRate,
           human_adoption_rate: data.authorBreakdown.humanAdoptionRate,
         },

--- a/src/formatters/text-formatter.ts
+++ b/src/formatters/text-formatter.ts
@@ -12,6 +12,8 @@ import type {
 import type { LoreAtom, TrailerKey } from '../types/domain.js';
 
 export class TextFormatter implements IOutputFormatter {
+  private static readonly BAR_WIDTH = 30;
+
   private readonly c: ChalkInstance;
 
   constructor(options: { color: boolean }) {
@@ -195,21 +197,36 @@ export class TextFormatter implements IOutputFormatter {
 
   formatMetricsResult(data: FormattableMetricsResult): string {
     const lines: string[] = [];
-    const BAR_WIDTH = 30;
 
-    // Header
+    this.renderMetricsHeader(data, lines);
+    this.renderAdoptionSection(data, lines);
+    this.renderDecisionDensitySection(data, lines);
+    this.renderTrailerCoverageSection(data, lines);
+    this.renderStalenessSection(data, lines);
+    this.renderSupersessionSection(data, lines);
+    this.renderConstraintCoverageSection(data, lines);
+    this.renderRejectionLibrarySection(data, lines);
+    this.renderAuthorBreakdownSection(data, lines);
+    this.renderBenchmarkingGuide(lines);
+
+    return lines.join('\n');
+  }
+
+  private renderMetricsHeader(data: FormattableMetricsResult, lines: string[]): void {
     const period = data.period.since ? `since ${data.period.since}` : 'all time';
     lines.push(this.c.bold('LORE METRICS DASHBOARD'));
     lines.push(this.c.dim(`Period: ${period}  |  Analyzed: ${data.period.analyzedAt.slice(0, 10)}`));
     lines.push('');
+  }
 
-    // 1. Adoption
+  private renderAdoptionSection(data: FormattableMetricsResult, lines: string[]): void {
     lines.push(this.c.bold.underline('Adoption'));
     lines.push(`  Lore commits:    ${this.alignRight(data.adoption.loreCommits, 6)} / ${data.adoption.totalCommits}`);
-    lines.push(`  Adoption rate:   ${this.progressBar(data.adoption.adoptionRate, BAR_WIDTH)} ${this.formatPercent(data.adoption.adoptionRate)}`);
+    lines.push(`  Adoption rate:   ${this.renderProgressBar(data.adoption.adoptionRate, TextFormatter.BAR_WIDTH)} ${this.formatPercent(data.adoption.adoptionRate)}`);
     lines.push('');
+  }
 
-    // 2. Decision Density
+  private renderDecisionDensitySection(data: FormattableMetricsResult, lines: string[]): void {
     lines.push(this.c.bold.underline('Decision Density'));
     lines.push(`  Files touched:   ${this.alignRight(data.decisionDensity.uniqueFilesTouched, 6)}`);
     lines.push(`  Files with atoms:${this.alignRight(data.decisionDensity.filesWithAtoms, 6)}`);
@@ -224,53 +241,60 @@ export class TextFormatter implements IOutputFormatter {
       }
     }
     lines.push('');
+  }
 
-    // 3. Trailer Coverage
+  private renderTrailerCoverageSection(data: FormattableMetricsResult, lines: string[]): void {
     lines.push(this.c.bold.underline('Trailer Coverage'));
     lines.push(`  Total atoms:     ${this.alignRight(data.trailerCoverage.totalAtoms, 6)}`);
     for (const t of data.trailerCoverage.trailers) {
       if (t.count > 0) {
         const label = `  ${t.trailer}:`;
         const padded = label.padEnd(20);
-        lines.push(`${padded}${this.alignRight(t.count, 5)}  ${this.progressBar(t.percentage / 100, BAR_WIDTH)} ${this.formatPercent(t.percentage / 100)}`);
+        lines.push(`${padded}${this.alignRight(t.count, 5)}  ${this.renderProgressBar(t.percentage / 100, TextFormatter.BAR_WIDTH)} ${this.formatPercent(t.percentage / 100)}`);
       }
     }
     lines.push('');
+  }
 
-    // 4. Staleness
+  private renderStalenessSection(data: FormattableMetricsResult, lines: string[]): void {
     lines.push(this.c.bold.underline('Staleness'));
     lines.push(`  Active atoms:    ${this.alignRight(data.staleness.totalActive, 6)}`);
     lines.push(`  Stale:           ${this.alignRight(data.staleness.staleCount, 6)}`);
-    lines.push(`  Staleness rate:  ${this.progressBar(data.staleness.stalenessRate, BAR_WIDTH)} ${this.formatPercent(data.staleness.stalenessRate)}`);
+    lines.push(`  Staleness rate:  ${this.renderProgressBar(data.staleness.stalenessRate, TextFormatter.BAR_WIDTH)} ${this.formatPercent(data.staleness.stalenessRate)}`);
     lines.push('');
+  }
 
-    // 5. Supersession Depth
+  private renderSupersessionSection(data: FormattableMetricsResult, lines: string[]): void {
     lines.push(this.c.bold.underline('Supersession Depth'));
     lines.push(`  Chains:          ${this.alignRight(data.supersessionDepth.totalChains, 6)}`);
     lines.push(`  Average depth:   ${this.alignRight(data.supersessionDepth.averageDepth, 6)}`);
     lines.push(`  Max depth:       ${this.alignRight(data.supersessionDepth.maxDepth, 6)}`);
     lines.push('');
+  }
 
-    // 6. Constraint Coverage
+  private renderConstraintCoverageSection(data: FormattableMetricsResult, lines: string[]): void {
     lines.push(this.c.bold.underline('Constraint Coverage'));
     lines.push(`  Repo files:      ${this.alignRight(data.constraintCoverage.totalRepoFiles, 6)}`);
     lines.push(`  With constraints:${this.alignRight(data.constraintCoverage.filesWithConstraint, 6)}`);
-    lines.push(`  Coverage rate:   ${this.progressBar(data.constraintCoverage.coverageRate, BAR_WIDTH)} ${this.formatPercent(data.constraintCoverage.coverageRate)}`);
+    lines.push(`  Coverage rate:   ${this.renderProgressBar(data.constraintCoverage.coverageRate, TextFormatter.BAR_WIDTH)} ${this.formatPercent(data.constraintCoverage.coverageRate)}`);
     lines.push('');
+  }
 
-    // 7. Rejection Library
+  private renderRejectionLibrarySection(data: FormattableMetricsResult, lines: string[]): void {
     lines.push(this.c.bold.underline('Rejection Library'));
     lines.push(`  Unique rejections:${this.alignRight(data.rejectionLibrary.uniqueRejections, 5)}`);
     lines.push(`  Total entries:   ${this.alignRight(data.rejectionLibrary.totalRejectionEntries, 6)}`);
     lines.push('');
+  }
 
-    // 8. Author Breakdown
+  private renderAuthorBreakdownSection(data: FormattableMetricsResult, lines: string[]): void {
     lines.push(this.c.bold.underline('Author Breakdown'));
-    lines.push(`  Agent commits:   ${this.alignRight(data.authorBreakdown.agentCommits, 6)}  adoption: ${this.formatPercent(data.authorBreakdown.agentAdoptionRate)}`);
-    lines.push(`  Human commits:   ${this.alignRight(data.authorBreakdown.humanCommits, 6)}  adoption: ${this.formatPercent(data.authorBreakdown.humanAdoptionRate)}`);
+    lines.push(`  Agent commits:   ${this.alignRight(data.authorBreakdown.agentLoreCommits, 6)}  adoption: ${this.formatPercent(data.authorBreakdown.agentAdoptionRate)}`);
+    lines.push(`  Human commits:   ${this.alignRight(data.authorBreakdown.humanLoreCommits, 6)}  adoption: ${this.formatPercent(data.authorBreakdown.humanAdoptionRate)}`);
     lines.push('');
+  }
 
-    // Benchmarking Guide
+  private renderBenchmarkingGuide(lines: string[]): void {
     lines.push(this.c.bold('\u2500'.repeat(60)));
     lines.push(this.c.bold('BENCHMARKING GUIDE'));
     lines.push('');
@@ -293,8 +317,6 @@ export class TextFormatter implements IOutputFormatter {
     lines.push('');
     lines.push(this.c.bold('Export for tracking:'));
     lines.push('  lore metrics --json > metrics-$(date +%Y-%m-%d).json');
-
-    return lines.join('\n');
   }
 
   formatSuccess(message: string, _data?: Record<string, unknown>): string {
@@ -403,7 +425,7 @@ export class TextFormatter implements IOutputFormatter {
     return date.toISOString().slice(0, 10);
   }
 
-  private progressBar(ratio: number, width: number): string {
+  private renderProgressBar(ratio: number, width: number): string {
     const clamped = Math.max(0, Math.min(1, ratio));
     const filled = Math.round(clamped * width);
     const empty = width - filled;

--- a/src/formatters/text-formatter.ts
+++ b/src/formatters/text-formatter.ts
@@ -7,6 +7,7 @@ import type {
   FormattableStalenessResult,
   FormattableTraceResult,
   FormattableDoctorResult,
+  FormattableMetricsResult,
 } from '../types/output.js';
 import type { LoreAtom, TrailerKey } from '../types/domain.js';
 
@@ -192,6 +193,110 @@ export class TextFormatter implements IOutputFormatter {
     return lines.join('\n');
   }
 
+  formatMetricsResult(data: FormattableMetricsResult): string {
+    const lines: string[] = [];
+    const BAR_WIDTH = 30;
+
+    // Header
+    const period = data.period.since ? `since ${data.period.since}` : 'all time';
+    lines.push(this.c.bold('LORE METRICS DASHBOARD'));
+    lines.push(this.c.dim(`Period: ${period}  |  Analyzed: ${data.period.analyzedAt.slice(0, 10)}`));
+    lines.push('');
+
+    // 1. Adoption
+    lines.push(this.c.bold.underline('Adoption'));
+    lines.push(`  Lore commits:    ${this.alignRight(data.adoption.loreCommits, 6)} / ${data.adoption.totalCommits}`);
+    lines.push(`  Adoption rate:   ${this.progressBar(data.adoption.adoptionRate, BAR_WIDTH)} ${this.formatPercent(data.adoption.adoptionRate)}`);
+    lines.push('');
+
+    // 2. Decision Density
+    lines.push(this.c.bold.underline('Decision Density'));
+    lines.push(`  Files touched:   ${this.alignRight(data.decisionDensity.uniqueFilesTouched, 6)}`);
+    lines.push(`  Files with atoms:${this.alignRight(data.decisionDensity.filesWithAtoms, 6)}`);
+    lines.push(`  Atoms per file:  ${this.alignRight(data.decisionDensity.atomsPerFile, 6)}`);
+    lines.push(`  Blind spots:     ${this.alignRight(data.decisionDensity.blindSpotCount, 6)}`);
+    if (data.decisionDensity.blindSpotFiles.length > 0) {
+      for (const file of data.decisionDensity.blindSpotFiles) {
+        lines.push(`    ${this.c.dim(file)}`);
+      }
+      if (data.decisionDensity.blindSpotCount > data.decisionDensity.blindSpotFiles.length) {
+        lines.push(`    ${this.c.dim(`... and ${data.decisionDensity.blindSpotCount - data.decisionDensity.blindSpotFiles.length} more`)}`);
+      }
+    }
+    lines.push('');
+
+    // 3. Trailer Coverage
+    lines.push(this.c.bold.underline('Trailer Coverage'));
+    lines.push(`  Total atoms:     ${this.alignRight(data.trailerCoverage.totalAtoms, 6)}`);
+    for (const t of data.trailerCoverage.trailers) {
+      if (t.count > 0) {
+        const label = `  ${t.trailer}:`;
+        const padded = label.padEnd(20);
+        lines.push(`${padded}${this.alignRight(t.count, 5)}  ${this.progressBar(t.percentage / 100, BAR_WIDTH)} ${this.formatPercent(t.percentage / 100)}`);
+      }
+    }
+    lines.push('');
+
+    // 4. Staleness
+    lines.push(this.c.bold.underline('Staleness'));
+    lines.push(`  Active atoms:    ${this.alignRight(data.staleness.totalActive, 6)}`);
+    lines.push(`  Stale:           ${this.alignRight(data.staleness.staleCount, 6)}`);
+    lines.push(`  Staleness rate:  ${this.progressBar(data.staleness.stalenessRate, BAR_WIDTH)} ${this.formatPercent(data.staleness.stalenessRate)}`);
+    lines.push('');
+
+    // 5. Supersession Depth
+    lines.push(this.c.bold.underline('Supersession Depth'));
+    lines.push(`  Chains:          ${this.alignRight(data.supersessionDepth.totalChains, 6)}`);
+    lines.push(`  Average depth:   ${this.alignRight(data.supersessionDepth.averageDepth, 6)}`);
+    lines.push(`  Max depth:       ${this.alignRight(data.supersessionDepth.maxDepth, 6)}`);
+    lines.push('');
+
+    // 6. Constraint Coverage
+    lines.push(this.c.bold.underline('Constraint Coverage'));
+    lines.push(`  Repo files:      ${this.alignRight(data.constraintCoverage.totalRepoFiles, 6)}`);
+    lines.push(`  With constraints:${this.alignRight(data.constraintCoverage.filesWithConstraint, 6)}`);
+    lines.push(`  Coverage rate:   ${this.progressBar(data.constraintCoverage.coverageRate, BAR_WIDTH)} ${this.formatPercent(data.constraintCoverage.coverageRate)}`);
+    lines.push('');
+
+    // 7. Rejection Library
+    lines.push(this.c.bold.underline('Rejection Library'));
+    lines.push(`  Unique rejections:${this.alignRight(data.rejectionLibrary.uniqueRejections, 5)}`);
+    lines.push(`  Total entries:   ${this.alignRight(data.rejectionLibrary.totalRejectionEntries, 6)}`);
+    lines.push('');
+
+    // 8. Author Breakdown
+    lines.push(this.c.bold.underline('Author Breakdown'));
+    lines.push(`  Agent commits:   ${this.alignRight(data.authorBreakdown.agentCommits, 6)}  adoption: ${this.formatPercent(data.authorBreakdown.agentAdoptionRate)}`);
+    lines.push(`  Human commits:   ${this.alignRight(data.authorBreakdown.humanCommits, 6)}  adoption: ${this.formatPercent(data.authorBreakdown.humanAdoptionRate)}`);
+    lines.push('');
+
+    // Benchmarking Guide
+    lines.push(this.c.bold('\u2500'.repeat(60)));
+    lines.push(this.c.bold('BENCHMARKING GUIDE'));
+    lines.push('');
+    lines.push(this.c.bold('Automatic metrics (above):'));
+    lines.push('  Adoption rate     How many commits carry Lore context.');
+    lines.push('  Trailer coverage  Which trailers teams actually use.');
+    lines.push('  Staleness rate    How much recorded knowledge has drifted.');
+    lines.push('  Constraint spread How much of the codebase has explicit constraints.');
+    lines.push('');
+    lines.push(this.c.bold('Manual metrics to track alongside:'));
+    lines.push('  Re-proposed rejections  How often rejected alternatives resurface.');
+    lines.push('  Review cycles           PR round-trips before merge (check your git host).');
+    lines.push('  Time-to-correct         Days between introducing a bug and fixing it.');
+    lines.push('  Onboarding time         Time for new contributors to make first meaningful PR.');
+    lines.push('');
+    lines.push(this.c.bold('Before / after comparison:'));
+    lines.push('  1. Run `lore metrics --since <start>` to capture a baseline.');
+    lines.push('  2. After adopting Lore for a sprint/month, run again.');
+    lines.push('  3. Compare adoption rate, staleness, and constraint coverage.');
+    lines.push('');
+    lines.push(this.c.bold('Export for tracking:'));
+    lines.push('  lore metrics --json > metrics-$(date +%Y-%m-%d).json');
+
+    return lines.join('\n');
+  }
+
   formatSuccess(message: string, _data?: Record<string, unknown>): string {
     return this.c.green(message);
   }
@@ -296,5 +401,20 @@ export class TextFormatter implements IOutputFormatter {
 
   private formatDate(date: Date): string {
     return date.toISOString().slice(0, 10);
+  }
+
+  private progressBar(ratio: number, width: number): string {
+    const clamped = Math.max(0, Math.min(1, ratio));
+    const filled = Math.round(clamped * width);
+    const empty = width - filled;
+    return this.c.green('\u2588'.repeat(filled)) + this.c.dim('\u2591'.repeat(empty));
+  }
+
+  private formatPercent(ratio: number): string {
+    return `${(ratio * 100).toFixed(1)}%`;
+  }
+
+  private alignRight(value: number | string, width: number): string {
+    return String(value).padStart(width);
   }
 }

--- a/src/interfaces/git-client.ts
+++ b/src/interfaces/git-client.ts
@@ -28,4 +28,6 @@ export interface IGitClient {
   getFilesChanged(commitHash: string): Promise<readonly string[]>;
   countCommitsSince(path: string, sinceCommitHash: string): Promise<number>;
   resolveRef(ref: string): Promise<string>;
+  countAllCommits(since?: string): Promise<number>;
+  listTrackedFiles(): Promise<readonly string[]>;
 }

--- a/src/interfaces/output-formatter.ts
+++ b/src/interfaces/output-formatter.ts
@@ -4,6 +4,7 @@ import type {
   FormattableStalenessResult,
   FormattableTraceResult,
   FormattableDoctorResult,
+  FormattableMetricsResult,
 } from '../types/output.js';
 
 export interface ErrorMessage {
@@ -18,6 +19,7 @@ export interface IOutputFormatter {
   formatStalenessResult(data: FormattableStalenessResult): string;
   formatTraceResult(data: FormattableTraceResult): string;
   formatDoctorResult(data: FormattableDoctorResult): string;
+  formatMetricsResult(data: FormattableMetricsResult): string;
   formatSuccess(message: string, data?: Record<string, unknown>): string;
   formatError(code: number, messages: readonly ErrorMessage[]): string;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,6 +37,7 @@ import { registerCommitCommand } from './commands/commit.js';
 import { registerValidateCommand } from './commands/validate.js';
 import { registerSquashCommand } from './commands/squash.js';
 import { registerDoctorCommand } from './commands/doctor.js';
+import { registerMetricsCommand } from './commands/metrics.js';
 
 import { LoreError } from './util/errors.js';
 
@@ -180,6 +181,15 @@ async function main(): Promise<void> {
   registerDoctorCommand(program, {
     atomRepository,
     configLoader,
+    getFormatter,
+  });
+
+  registerMetricsCommand(program, {
+    atomRepository,
+    supersessionResolver,
+    stalenessDetector,
+    gitClient,
+    config,
     getFormatter,
   });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,7 @@ import { Validator } from './services/validator.js';
 import { TerminalPrompt } from './services/terminal-prompt.js';
 import { CommitInputResolver } from './services/commit-input-resolver.js';
 import { SearchFilter } from './services/search-filter.js';
+import { MetricsCollector } from './services/metrics-collector.js';
 
 import { TextFormatter } from './formatters/text-formatter.js';
 import { JsonFormatter } from './formatters/json-formatter.js';
@@ -91,6 +92,7 @@ async function main(): Promise<void> {
   const searchFilter = new SearchFilter();
   const prompt = new TerminalPrompt();
   const commitInputResolver = new CommitInputResolver(prompt);
+  const metricsCollector = new MetricsCollector();
 
   // 4. Formatter factory (reads --format/--json from program options at call time)
   // Memoized: the formatter is created once on first call and reused thereafter.
@@ -189,7 +191,7 @@ async function main(): Promise<void> {
     supersessionResolver,
     stalenessDetector,
     gitClient,
-    config,
+    metricsCollector,
     getFormatter,
   });
 

--- a/src/services/git-client.ts
+++ b/src/services/git-client.ts
@@ -137,6 +137,18 @@ export class GitClient implements IGitClient {
     return stdout.trim();
   }
 
+  async countAllCommits(since?: string): Promise<number> {
+    const args = ['rev-list', '--count', 'HEAD'];
+    if (since) args.push(`--since=${since}`);
+    const stdout = await this.exec(args);
+    return parseInt(stdout.trim(), 10) || 0;
+  }
+
+  async listTrackedFiles(): Promise<readonly string[]> {
+    const stdout = await this.exec(['ls-files']);
+    return stdout.trim().split('\n').filter(line => line.length > 0);
+  }
+
   /**
    * Parse the standard git log output with our custom format.
    * Records are separated by double null bytes; fields within a record

--- a/src/services/metrics-collector.ts
+++ b/src/services/metrics-collector.ts
@@ -11,6 +11,7 @@ import type {
   RejectionLibraryMetrics,
   AuthorBreakdownMetrics,
 } from '../types/output.js';
+import { MAX_BLIND_SPOT_DISPLAY } from '../util/constants.js';
 
 /**
  * Patterns used to identify agent/bot commit authors.
@@ -90,7 +91,7 @@ export class MetricsCollector {
     const filesWithAtomsSet = new Set(fileAtomCounts.keys());
     const allBlindSpots = input.allRepoFiles.filter(f => !filesWithAtomsSet.has(f));
     const blindSpotCount = allBlindSpots.length;
-    const blindSpotFiles = allBlindSpots.slice(0, 10);
+    const blindSpotFiles = allBlindSpots.slice(0, MAX_BLIND_SPOT_DISPLAY);
 
     return {
       uniqueFilesTouched,
@@ -239,7 +240,7 @@ export class MetricsCollector {
     for (const atom of input.atoms) {
       for (const rejection of atom.trailers.Rejected) {
         totalRejectionEntries++;
-        // Normalize: lowercase, trim, strip trailing pipe and reason for dedup
+        // Normalize: lowercase and trim for dedup
         const normalized = rejection.trim().toLowerCase();
         uniqueRejections.add(normalized);
       }
@@ -285,8 +286,8 @@ export class MetricsCollector {
     const humanAdoptionRate = humanTotalEstimate > 0 ? humanLoreCommits / humanTotalEstimate : 0;
 
     return {
-      agentCommits: agentLoreCommits,
-      humanCommits: humanLoreCommits,
+      agentLoreCommits,
+      humanLoreCommits,
       agentAdoptionRate,
       humanAdoptionRate,
     };

--- a/src/services/metrics-collector.ts
+++ b/src/services/metrics-collector.ts
@@ -1,0 +1,299 @@
+import type { LoreAtom, SupersessionStatus } from '../types/domain.js';
+import type {
+  FormattableMetricsResult,
+  AdoptionMetrics,
+  DecisionDensityMetrics,
+  TrailerCoverageMetrics,
+  TrailerUsage,
+  StalenessMetrics,
+  SupersessionDepthMetrics,
+  ConstraintCoverageMetrics,
+  RejectionLibraryMetrics,
+  AuthorBreakdownMetrics,
+} from '../types/output.js';
+
+/**
+ * Patterns used to identify agent/bot commit authors.
+ * Best-effort heuristics -- extend as new agents emerge.
+ */
+const AGENT_AUTHOR_PATTERNS: readonly string[] = [
+  'noreply@anthropic',
+  'noreply@github',
+  'copilot',
+  'devin',
+  'cursor',
+  'codeium',
+  'windsurf',
+  'claude',
+];
+
+/**
+ * Input data required by MetricsCollector.
+ * All I/O is performed by the caller; the collector is pure computation.
+ */
+export interface MetricsInput {
+  readonly atoms: readonly LoreAtom[];
+  readonly supersessionMap: ReadonlyMap<string, SupersessionStatus>;
+  readonly staleAtomIds: ReadonlySet<string>;
+  readonly totalCommitCount: number;
+  readonly allRepoFiles: readonly string[];
+  readonly since: string | null;
+}
+
+/**
+ * Stateless service that computes all 8 metric categories from pre-fetched data.
+ *
+ * GRASP: Pure Fabrication -- no domain identity, exists solely to aggregate metrics.
+ * SOLID: SRP -- only metric computation, no I/O.
+ */
+export class MetricsCollector {
+  collectAll(input: MetricsInput): FormattableMetricsResult {
+    return {
+      period: {
+        since: input.since,
+        analyzedAt: new Date().toISOString(),
+      },
+      adoption: this.computeAdoption(input),
+      decisionDensity: this.computeDecisionDensity(input),
+      trailerCoverage: this.computeTrailerCoverage(input),
+      staleness: this.computeStaleness(input),
+      supersessionDepth: this.computeSupersessionDepth(input),
+      constraintCoverage: this.computeConstraintCoverage(input),
+      rejectionLibrary: this.computeRejectionLibrary(input),
+      authorBreakdown: this.computeAuthorBreakdown(input),
+    };
+  }
+
+  private computeAdoption(input: MetricsInput): AdoptionMetrics {
+    const totalCommits = input.totalCommitCount;
+    const loreCommits = input.atoms.length;
+    const adoptionRate = totalCommits > 0 ? loreCommits / totalCommits : 0;
+
+    return { totalCommits, loreCommits, adoptionRate };
+  }
+
+  private computeDecisionDensity(input: MetricsInput): DecisionDensityMetrics {
+    const fileAtomCounts = new Map<string, number>();
+
+    for (const atom of input.atoms) {
+      for (const file of atom.filesChanged) {
+        fileAtomCounts.set(file, (fileAtomCounts.get(file) ?? 0) + 1);
+      }
+    }
+
+    const uniqueFilesTouched = fileAtomCounts.size;
+    const filesWithAtoms = uniqueFilesTouched;
+    const totalAtomFileRefs = Array.from(fileAtomCounts.values()).reduce((sum, c) => sum + c, 0);
+    const atomsPerFile = uniqueFilesTouched > 0 ? totalAtomFileRefs / uniqueFilesTouched : 0;
+
+    // Blind spots: repo files not touched by any atom
+    const filesWithAtomsSet = new Set(fileAtomCounts.keys());
+    const allBlindSpots = input.allRepoFiles.filter(f => !filesWithAtomsSet.has(f));
+    const blindSpotCount = allBlindSpots.length;
+    const blindSpotFiles = allBlindSpots.slice(0, 10);
+
+    return {
+      uniqueFilesTouched,
+      filesWithAtoms,
+      atomsPerFile: Math.round(atomsPerFile * 100) / 100,
+      blindSpotFiles,
+      blindSpotCount,
+    };
+  }
+
+  private computeTrailerCoverage(input: MetricsInput): TrailerCoverageMetrics {
+    const totalAtoms = input.atoms.length;
+    const trailerKeys: readonly { key: string; check: (atom: LoreAtom) => boolean }[] = [
+      { key: 'Constraint', check: (a) => a.trailers.Constraint.length > 0 },
+      { key: 'Rejected', check: (a) => a.trailers.Rejected.length > 0 },
+      { key: 'Confidence', check: (a) => a.trailers.Confidence !== null },
+      { key: 'Scope-risk', check: (a) => a.trailers['Scope-risk'] !== null },
+      { key: 'Reversibility', check: (a) => a.trailers.Reversibility !== null },
+      { key: 'Directive', check: (a) => a.trailers.Directive.length > 0 },
+      { key: 'Tested', check: (a) => a.trailers.Tested.length > 0 },
+      { key: 'Not-tested', check: (a) => a.trailers['Not-tested'].length > 0 },
+      { key: 'Supersedes', check: (a) => a.trailers.Supersedes.length > 0 },
+      { key: 'Depends-on', check: (a) => a.trailers['Depends-on'].length > 0 },
+      { key: 'Related', check: (a) => a.trailers.Related.length > 0 },
+    ];
+
+    const trailers: TrailerUsage[] = trailerKeys.map(({ key, check }) => {
+      const count = input.atoms.filter(check).length;
+      return {
+        trailer: key,
+        count,
+        percentage: totalAtoms > 0 ? Math.round((count / totalAtoms) * 10000) / 100 : 0,
+      };
+    });
+
+    return { totalAtoms, trailers };
+  }
+
+  private computeStaleness(input: MetricsInput): StalenessMetrics {
+    // Count active atoms (not superseded)
+    const activeAtoms = input.atoms.filter(atom => {
+      const status = input.supersessionMap.get(atom.loreId);
+      return status === undefined || !status.superseded;
+    });
+
+    const totalActive = activeAtoms.length;
+    const staleCount = activeAtoms.filter(atom => input.staleAtomIds.has(atom.loreId)).length;
+    const stalenessRate = totalActive > 0 ? staleCount / totalActive : 0;
+
+    return { totalActive, staleCount, stalenessRate };
+  }
+
+  private computeSupersessionDepth(input: MetricsInput): SupersessionDepthMetrics {
+    // Build a graph of supersession chains: for each superseded atom, find its chain depth
+    const supersededBy = new Map<string, string>();
+    for (const [id, status] of input.supersessionMap) {
+      if (status.superseded && status.supersededBy !== null) {
+        supersededBy.set(id, status.supersededBy);
+      }
+    }
+
+    if (supersededBy.size === 0) {
+      return { totalChains: 0, averageDepth: 0, maxDepth: 0 };
+    }
+
+    // Find chain roots: atoms that supersede others but are NOT themselves superseded
+    const chainRoots = new Set<string>();
+    for (const [, superseder] of supersededBy) {
+      if (!supersededBy.has(superseder)) {
+        chainRoots.add(superseder);
+      }
+    }
+
+    // For each root, walk down to find depth
+    // Build reverse map: superseder -> list of superseded
+    const supersedes = new Map<string, string[]>();
+    for (const [superseded, superseder] of supersededBy) {
+      const existing = supersedes.get(superseder) ?? [];
+      existing.push(superseded);
+      supersedes.set(superseder, existing);
+    }
+
+    const depths: number[] = [];
+    for (const root of chainRoots) {
+      const maxBranchDepth = this.walkChainDepth(root, supersedes, new Set<string>());
+      if (maxBranchDepth > 0) {
+        depths.push(maxBranchDepth);
+      }
+    }
+
+    const totalChains = depths.length;
+    const maxDepth = depths.length > 0 ? Math.max(...depths) : 0;
+    const averageDepth = depths.length > 0
+      ? Math.round((depths.reduce((s, d) => s + d, 0) / depths.length) * 100) / 100
+      : 0;
+
+    return { totalChains, averageDepth, maxDepth };
+  }
+
+  private walkChainDepth(
+    nodeId: string,
+    supersedes: ReadonlyMap<string, string[]>,
+    visited: Set<string>,
+  ): number {
+    if (visited.has(nodeId)) return 0;
+    visited.add(nodeId);
+
+    const children = supersedes.get(nodeId);
+    if (!children || children.length === 0) return 0;
+
+    let maxChildDepth = 0;
+    for (const child of children) {
+      const childDepth = this.walkChainDepth(child, supersedes, visited);
+      maxChildDepth = Math.max(maxChildDepth, childDepth);
+    }
+
+    return 1 + maxChildDepth;
+  }
+
+  private computeConstraintCoverage(input: MetricsInput): ConstraintCoverageMetrics {
+    const totalRepoFiles = input.allRepoFiles.length;
+
+    // Files that appear in atoms with at least one Constraint trailer
+    const filesWithConstraint = new Set<string>();
+    for (const atom of input.atoms) {
+      if (atom.trailers.Constraint.length > 0) {
+        for (const file of atom.filesChanged) {
+          filesWithConstraint.add(file);
+        }
+      }
+    }
+
+    const coverageRate = totalRepoFiles > 0 ? filesWithConstraint.size / totalRepoFiles : 0;
+
+    return {
+      totalRepoFiles,
+      filesWithConstraint: filesWithConstraint.size,
+      coverageRate,
+    };
+  }
+
+  private computeRejectionLibrary(input: MetricsInput): RejectionLibraryMetrics {
+    const uniqueRejections = new Set<string>();
+    let totalRejectionEntries = 0;
+
+    for (const atom of input.atoms) {
+      for (const rejection of atom.trailers.Rejected) {
+        totalRejectionEntries++;
+        // Normalize: lowercase, trim, strip trailing pipe and reason for dedup
+        const normalized = rejection.trim().toLowerCase();
+        uniqueRejections.add(normalized);
+      }
+    }
+
+    return {
+      uniqueRejections: uniqueRejections.size,
+      totalRejectionEntries,
+    };
+  }
+
+  private computeAuthorBreakdown(input: MetricsInput): AuthorBreakdownMetrics {
+    let agentLoreCommits = 0;
+    let humanLoreCommits = 0;
+    let agentTotalEstimate = 0;
+    let humanTotalEstimate = 0;
+
+    // Count Lore atoms by author type
+    for (const atom of input.atoms) {
+      if (this.isAgentAuthor(atom.author)) {
+        agentLoreCommits++;
+      } else {
+        humanLoreCommits++;
+      }
+    }
+
+    // Estimate total agent vs. human commits based on the ratio in Lore commits.
+    // Without full commit history author data, we use the Lore atom breakdown
+    // as a proxy and scale to total commits.
+    const totalLore = input.atoms.length;
+    const totalCommits = input.totalCommitCount;
+
+    if (totalLore > 0 && totalCommits > 0) {
+      const agentRatio = agentLoreCommits / totalLore;
+      agentTotalEstimate = Math.round(agentRatio * totalCommits);
+      humanTotalEstimate = totalCommits - agentTotalEstimate;
+    } else {
+      agentTotalEstimate = 0;
+      humanTotalEstimate = totalCommits;
+    }
+
+    const agentAdoptionRate = agentTotalEstimate > 0 ? agentLoreCommits / agentTotalEstimate : 0;
+    const humanAdoptionRate = humanTotalEstimate > 0 ? humanLoreCommits / humanTotalEstimate : 0;
+
+    return {
+      agentCommits: agentLoreCommits,
+      humanCommits: humanLoreCommits,
+      agentAdoptionRate,
+      humanAdoptionRate,
+    };
+  }
+
+  private isAgentAuthor(author: string): boolean {
+    const lower = author.toLowerCase();
+    return AGENT_AUTHOR_PATTERNS.some(pattern => lower.includes(pattern));
+  }
+}

--- a/src/types/output.ts
+++ b/src/types/output.ts
@@ -59,6 +59,78 @@ export interface FormattableDoctorResult {
   readonly summary: { errors: number; warnings: number; info: number };
 }
 
+export interface FormattableMetricsResult {
+  readonly period: MetricsPeriod;
+  readonly adoption: AdoptionMetrics;
+  readonly decisionDensity: DecisionDensityMetrics;
+  readonly trailerCoverage: TrailerCoverageMetrics;
+  readonly staleness: StalenessMetrics;
+  readonly supersessionDepth: SupersessionDepthMetrics;
+  readonly constraintCoverage: ConstraintCoverageMetrics;
+  readonly rejectionLibrary: RejectionLibraryMetrics;
+  readonly authorBreakdown: AuthorBreakdownMetrics;
+}
+
+export interface MetricsPeriod {
+  readonly since: string | null;
+  readonly analyzedAt: string;
+}
+
+export interface AdoptionMetrics {
+  readonly totalCommits: number;
+  readonly loreCommits: number;
+  readonly adoptionRate: number;
+}
+
+export interface DecisionDensityMetrics {
+  readonly uniqueFilesTouched: number;
+  readonly filesWithAtoms: number;
+  readonly atomsPerFile: number;
+  readonly blindSpotFiles: readonly string[];
+  readonly blindSpotCount: number;
+}
+
+export interface TrailerCoverageMetrics {
+  readonly totalAtoms: number;
+  readonly trailers: readonly TrailerUsage[];
+}
+
+export interface TrailerUsage {
+  readonly trailer: string;
+  readonly count: number;
+  readonly percentage: number;
+}
+
+export interface StalenessMetrics {
+  readonly totalActive: number;
+  readonly staleCount: number;
+  readonly stalenessRate: number;
+}
+
+export interface SupersessionDepthMetrics {
+  readonly totalChains: number;
+  readonly averageDepth: number;
+  readonly maxDepth: number;
+}
+
+export interface ConstraintCoverageMetrics {
+  readonly totalRepoFiles: number;
+  readonly filesWithConstraint: number;
+  readonly coverageRate: number;
+}
+
+export interface RejectionLibraryMetrics {
+  readonly uniqueRejections: number;
+  readonly totalRejectionEntries: number;
+}
+
+export interface AuthorBreakdownMetrics {
+  readonly agentCommits: number;
+  readonly humanCommits: number;
+  readonly agentAdoptionRate: number;
+  readonly humanAdoptionRate: number;
+}
+
 export interface DoctorCheck {
   readonly name: string;
   readonly status: 'ok' | 'error' | 'warning' | 'info';

--- a/src/types/output.ts
+++ b/src/types/output.ts
@@ -125,8 +125,8 @@ export interface RejectionLibraryMetrics {
 }
 
 export interface AuthorBreakdownMetrics {
-  readonly agentCommits: number;
-  readonly humanCommits: number;
+  readonly agentLoreCommits: number;
+  readonly humanLoreCommits: number;
   readonly agentAdoptionRate: number;
   readonly humanAdoptionRate: number;
 }

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -46,6 +46,8 @@ export const DEFAULT_STALE_OLDER_THAN = '6m';
 export const DEFAULT_STALE_DRIFT_THRESHOLD = 20;
 export const GIT_FILES_CHANGED_BATCH_SIZE = 20;
 
+export const MAX_BLIND_SPOT_DISPLAY = 10;
+
 export const CONFIG_FILENAME = 'config.toml';
 export const CONFIG_DIR = '.lore';
 

--- a/tests/unit/services/metrics-collector.test.ts
+++ b/tests/unit/services/metrics-collector.test.ts
@@ -1,0 +1,531 @@
+import { describe, it, expect } from 'vitest';
+import { MetricsCollector } from '../../../src/services/metrics-collector.js';
+import type { MetricsInput } from '../../../src/services/metrics-collector.js';
+import type { LoreAtom, LoreTrailers, SupersessionStatus } from '../../../src/types/domain.js';
+
+function makeAtom(options: {
+  loreId: string;
+  author?: string;
+  filesChanged?: string[];
+  constraints?: string[];
+  rejected?: string[];
+  confidence?: 'low' | 'medium' | 'high' | null;
+  supersedes?: string[];
+  dependsOn?: string[];
+  directive?: string[];
+  tested?: string[];
+  notTested?: string[];
+  related?: string[];
+  scopeRisk?: 'narrow' | 'moderate' | 'wide' | null;
+  reversibility?: 'clean' | 'migration-needed' | 'irreversible' | null;
+}): LoreAtom {
+  return {
+    loreId: options.loreId,
+    commitHash: `hash-${options.loreId}`,
+    date: new Date('2025-06-15T10:00:00Z'),
+    author: options.author ?? 'dev@example.com',
+    intent: 'test commit',
+    body: '',
+    trailers: {
+      'Lore-id': options.loreId,
+      Constraint: options.constraints ?? [],
+      Rejected: options.rejected ?? [],
+      Confidence: options.confidence ?? null,
+      'Scope-risk': options.scopeRisk ?? null,
+      Reversibility: options.reversibility ?? null,
+      Directive: options.directive ?? [],
+      Tested: options.tested ?? [],
+      'Not-tested': options.notTested ?? [],
+      Supersedes: options.supersedes ?? [],
+      'Depends-on': options.dependsOn ?? [],
+      Related: options.related ?? [],
+      custom: new Map(),
+    } as LoreTrailers,
+    filesChanged: options.filesChanged ?? [],
+  };
+}
+
+function makeSupersessionMap(entries: Array<[string, boolean, string | null]>): Map<string, SupersessionStatus> {
+  const map = new Map<string, SupersessionStatus>();
+  for (const [id, superseded, supersededBy] of entries) {
+    map.set(id, { superseded, supersededBy });
+  }
+  return map;
+}
+
+describe('MetricsCollector', () => {
+  let collector: MetricsCollector;
+
+  beforeEach(() => {
+    collector = new MetricsCollector();
+  });
+
+  describe('empty input', () => {
+    it('should return zero values for all metrics with 0 commits and 0 atoms', () => {
+      const input: MetricsInput = {
+        atoms: [],
+        supersessionMap: new Map(),
+        staleAtomIds: new Set(),
+        totalCommitCount: 0,
+        allRepoFiles: [],
+        since: null,
+      };
+
+      const result = collector.collectAll(input);
+
+      expect(result.adoption.totalCommits).toBe(0);
+      expect(result.adoption.loreCommits).toBe(0);
+      expect(result.adoption.adoptionRate).toBe(0);
+      expect(result.decisionDensity.uniqueFilesTouched).toBe(0);
+      expect(result.decisionDensity.atomsPerFile).toBe(0);
+      expect(result.decisionDensity.blindSpotCount).toBe(0);
+      expect(result.trailerCoverage.totalAtoms).toBe(0);
+      expect(result.staleness.totalActive).toBe(0);
+      expect(result.staleness.staleCount).toBe(0);
+      expect(result.staleness.stalenessRate).toBe(0);
+      expect(result.supersessionDepth.totalChains).toBe(0);
+      expect(result.supersessionDepth.averageDepth).toBe(0);
+      expect(result.supersessionDepth.maxDepth).toBe(0);
+      expect(result.constraintCoverage.totalRepoFiles).toBe(0);
+      expect(result.constraintCoverage.filesWithConstraint).toBe(0);
+      expect(result.constraintCoverage.coverageRate).toBe(0);
+      expect(result.rejectionLibrary.uniqueRejections).toBe(0);
+      expect(result.rejectionLibrary.totalRejectionEntries).toBe(0);
+      expect(result.authorBreakdown.agentCommits).toBe(0);
+      expect(result.authorBreakdown.humanCommits).toBe(0);
+    });
+  });
+
+  describe('100% adoption', () => {
+    it('should report 100% adoption when all commits are lore commits', () => {
+      const atoms = [
+        makeAtom({ loreId: 'aaaa1111' }),
+        makeAtom({ loreId: 'bbbb2222' }),
+        makeAtom({ loreId: 'cccc3333' }),
+      ];
+
+      const input: MetricsInput = {
+        atoms,
+        supersessionMap: makeSupersessionMap([
+          ['aaaa1111', false, null],
+          ['bbbb2222', false, null],
+          ['cccc3333', false, null],
+        ]),
+        staleAtomIds: new Set(),
+        totalCommitCount: 3,
+        allRepoFiles: [],
+        since: null,
+      };
+
+      const result = collector.collectAll(input);
+
+      expect(result.adoption.adoptionRate).toBe(1);
+      expect(result.adoption.loreCommits).toBe(3);
+      expect(result.adoption.totalCommits).toBe(3);
+    });
+  });
+
+  describe('partial adoption with mixed agent/human', () => {
+    it('should correctly separate agent and human commits', () => {
+      const atoms = [
+        makeAtom({ loreId: 'aaaa1111', author: 'noreply@anthropic.com' }),
+        makeAtom({ loreId: 'bbbb2222', author: 'claude@ai.com' }),
+        makeAtom({ loreId: 'cccc3333', author: 'dev@example.com' }),
+        makeAtom({ loreId: 'dddd4444', author: 'human@company.com' }),
+      ];
+
+      const input: MetricsInput = {
+        atoms,
+        supersessionMap: makeSupersessionMap([
+          ['aaaa1111', false, null],
+          ['bbbb2222', false, null],
+          ['cccc3333', false, null],
+          ['dddd4444', false, null],
+        ]),
+        staleAtomIds: new Set(),
+        totalCommitCount: 10,
+        allRepoFiles: [],
+        since: null,
+      };
+
+      const result = collector.collectAll(input);
+
+      expect(result.authorBreakdown.agentCommits).toBe(2);
+      expect(result.authorBreakdown.humanCommits).toBe(2);
+      expect(result.adoption.adoptionRate).toBe(0.4);
+    });
+
+    it('should detect copilot, devin, cursor, codeium, windsurf as agents', () => {
+      const agents = [
+        makeAtom({ loreId: 'aaaa1111', author: 'copilot[bot]@users.noreply@github.com' }),
+        makeAtom({ loreId: 'bbbb2222', author: 'devin@cognition.ai' }),
+        makeAtom({ loreId: 'cccc3333', author: 'cursor-ai@noreply.com' }),
+        makeAtom({ loreId: 'dddd4444', author: 'codeium-bot@example.com' }),
+        makeAtom({ loreId: 'eeee5555', author: 'windsurf-agent@corp.com' }),
+      ];
+
+      const input: MetricsInput = {
+        atoms: agents,
+        supersessionMap: makeSupersessionMap(
+          agents.map(a => [a.loreId, false, null] as [string, boolean, string | null]),
+        ),
+        staleAtomIds: new Set(),
+        totalCommitCount: 5,
+        allRepoFiles: [],
+        since: null,
+      };
+
+      const result = collector.collectAll(input);
+
+      expect(result.authorBreakdown.agentCommits).toBe(5);
+      expect(result.authorBreakdown.humanCommits).toBe(0);
+    });
+  });
+
+  describe('trailer coverage', () => {
+    it('should compute correct percentages for varied trailer usage', () => {
+      const atoms = [
+        makeAtom({
+          loreId: 'aaaa1111',
+          constraints: ['Must be fast'],
+          rejected: ['Alternative A | too slow'],
+          confidence: 'high',
+        }),
+        makeAtom({
+          loreId: 'bbbb2222',
+          constraints: ['Must be safe'],
+          tested: ['Unit tests pass'],
+        }),
+        makeAtom({
+          loreId: 'cccc3333',
+          rejected: ['Alternative B | too complex'],
+          directive: ['Use pattern X'],
+        }),
+        makeAtom({
+          loreId: 'dddd4444',
+        }),
+      ];
+
+      const input: MetricsInput = {
+        atoms,
+        supersessionMap: makeSupersessionMap(
+          atoms.map(a => [a.loreId, false, null] as [string, boolean, string | null]),
+        ),
+        staleAtomIds: new Set(),
+        totalCommitCount: 4,
+        allRepoFiles: [],
+        since: null,
+      };
+
+      const result = collector.collectAll(input);
+
+      expect(result.trailerCoverage.totalAtoms).toBe(4);
+
+      const constraintUsage = result.trailerCoverage.trailers.find(t => t.trailer === 'Constraint');
+      expect(constraintUsage?.count).toBe(2);
+      expect(constraintUsage?.percentage).toBe(50);
+
+      const rejectedUsage = result.trailerCoverage.trailers.find(t => t.trailer === 'Rejected');
+      expect(rejectedUsage?.count).toBe(2);
+      expect(rejectedUsage?.percentage).toBe(50);
+
+      const confidenceUsage = result.trailerCoverage.trailers.find(t => t.trailer === 'Confidence');
+      expect(confidenceUsage?.count).toBe(1);
+      expect(confidenceUsage?.percentage).toBe(25);
+
+      const testedUsage = result.trailerCoverage.trailers.find(t => t.trailer === 'Tested');
+      expect(testedUsage?.count).toBe(1);
+      expect(testedUsage?.percentage).toBe(25);
+
+      const directiveUsage = result.trailerCoverage.trailers.find(t => t.trailer === 'Directive');
+      expect(directiveUsage?.count).toBe(1);
+      expect(directiveUsage?.percentage).toBe(25);
+    });
+  });
+
+  describe('supersession chains', () => {
+    it('should report zero chains when no supersessions exist', () => {
+      const atoms = [
+        makeAtom({ loreId: 'aaaa1111' }),
+        makeAtom({ loreId: 'bbbb2222' }),
+      ];
+
+      const input: MetricsInput = {
+        atoms,
+        supersessionMap: makeSupersessionMap([
+          ['aaaa1111', false, null],
+          ['bbbb2222', false, null],
+        ]),
+        staleAtomIds: new Set(),
+        totalCommitCount: 2,
+        allRepoFiles: [],
+        since: null,
+      };
+
+      const result = collector.collectAll(input);
+
+      expect(result.supersessionDepth.totalChains).toBe(0);
+      expect(result.supersessionDepth.averageDepth).toBe(0);
+      expect(result.supersessionDepth.maxDepth).toBe(0);
+    });
+
+    it('should report shallow chain: A supersedes B', () => {
+      const atoms = [
+        makeAtom({ loreId: 'aaaa1111', supersedes: ['bbbb2222'] }),
+        makeAtom({ loreId: 'bbbb2222' }),
+      ];
+
+      const input: MetricsInput = {
+        atoms,
+        supersessionMap: makeSupersessionMap([
+          ['aaaa1111', false, null],
+          ['bbbb2222', true, 'aaaa1111'],
+        ]),
+        staleAtomIds: new Set(),
+        totalCommitCount: 2,
+        allRepoFiles: [],
+        since: null,
+      };
+
+      const result = collector.collectAll(input);
+
+      expect(result.supersessionDepth.totalChains).toBe(1);
+      expect(result.supersessionDepth.maxDepth).toBe(1);
+    });
+
+    it('should report deep chain: A -> B -> C -> D', () => {
+      const atoms = [
+        makeAtom({ loreId: 'aaaa1111', supersedes: ['bbbb2222'] }),
+        makeAtom({ loreId: 'bbbb2222', supersedes: ['cccc3333'] }),
+        makeAtom({ loreId: 'cccc3333', supersedes: ['dddd4444'] }),
+        makeAtom({ loreId: 'dddd4444' }),
+      ];
+
+      // The supersession map reflects the actual chain edges:
+      // A supersedes B, B supersedes C, C supersedes D
+      const input: MetricsInput = {
+        atoms,
+        supersessionMap: makeSupersessionMap([
+          ['aaaa1111', false, null],
+          ['bbbb2222', true, 'aaaa1111'],
+          ['cccc3333', true, 'bbbb2222'],
+          ['dddd4444', true, 'cccc3333'],
+        ]),
+        staleAtomIds: new Set(),
+        totalCommitCount: 4,
+        allRepoFiles: [],
+        since: null,
+      };
+
+      const result = collector.collectAll(input);
+
+      expect(result.supersessionDepth.totalChains).toBe(1);
+      expect(result.supersessionDepth.maxDepth).toBe(3);
+    });
+  });
+
+  describe('constraint coverage', () => {
+    it('should compute coverage for repo files with constraints', () => {
+      const atoms = [
+        makeAtom({
+          loreId: 'aaaa1111',
+          constraints: ['Must be idempotent'],
+          filesChanged: ['src/main.ts', 'src/util.ts'],
+        }),
+        makeAtom({
+          loreId: 'bbbb2222',
+          filesChanged: ['src/other.ts'],
+        }),
+      ];
+
+      const input: MetricsInput = {
+        atoms,
+        supersessionMap: makeSupersessionMap([
+          ['aaaa1111', false, null],
+          ['bbbb2222', false, null],
+        ]),
+        staleAtomIds: new Set(),
+        totalCommitCount: 2,
+        allRepoFiles: ['src/main.ts', 'src/util.ts', 'src/other.ts', 'src/index.ts'],
+        since: null,
+      };
+
+      const result = collector.collectAll(input);
+
+      expect(result.constraintCoverage.totalRepoFiles).toBe(4);
+      expect(result.constraintCoverage.filesWithConstraint).toBe(2);
+      expect(result.constraintCoverage.coverageRate).toBe(0.5);
+    });
+  });
+
+  describe('rejection deduplication', () => {
+    it('should count unique rejections after normalization', () => {
+      const atoms = [
+        makeAtom({
+          loreId: 'aaaa1111',
+          rejected: ['Use MongoDB | too complex', 'Use Redis | overkill'],
+        }),
+        makeAtom({
+          loreId: 'bbbb2222',
+          rejected: ['use mongodb | too complex', 'Use GraphQL | over-engineered'],
+        }),
+      ];
+
+      const input: MetricsInput = {
+        atoms,
+        supersessionMap: makeSupersessionMap([
+          ['aaaa1111', false, null],
+          ['bbbb2222', false, null],
+        ]),
+        staleAtomIds: new Set(),
+        totalCommitCount: 2,
+        allRepoFiles: [],
+        since: null,
+      };
+
+      const result = collector.collectAll(input);
+
+      expect(result.rejectionLibrary.totalRejectionEntries).toBe(4);
+      expect(result.rejectionLibrary.uniqueRejections).toBe(3);
+    });
+  });
+
+  describe('staleness', () => {
+    it('should report correct staleness rate', () => {
+      const atoms = [
+        makeAtom({ loreId: 'aaaa1111' }),
+        makeAtom({ loreId: 'bbbb2222' }),
+        makeAtom({ loreId: 'cccc3333' }),
+      ];
+
+      const input: MetricsInput = {
+        atoms,
+        supersessionMap: makeSupersessionMap([
+          ['aaaa1111', false, null],
+          ['bbbb2222', false, null],
+          ['cccc3333', false, null],
+        ]),
+        staleAtomIds: new Set(['aaaa1111']),
+        totalCommitCount: 3,
+        allRepoFiles: [],
+        since: null,
+      };
+
+      const result = collector.collectAll(input);
+
+      expect(result.staleness.totalActive).toBe(3);
+      expect(result.staleness.staleCount).toBe(1);
+      expect(result.staleness.stalenessRate).toBeCloseTo(1 / 3);
+    });
+
+    it('should not count superseded atoms as stale', () => {
+      const atoms = [
+        makeAtom({ loreId: 'aaaa1111' }),
+        makeAtom({ loreId: 'bbbb2222' }),
+      ];
+
+      const input: MetricsInput = {
+        atoms,
+        supersessionMap: makeSupersessionMap([
+          ['aaaa1111', false, null],
+          ['bbbb2222', true, 'aaaa1111'],
+        ]),
+        staleAtomIds: new Set(['bbbb2222']),
+        totalCommitCount: 2,
+        allRepoFiles: [],
+        since: null,
+      };
+
+      const result = collector.collectAll(input);
+
+      // Only aaaa1111 is active, bbbb2222 is superseded
+      expect(result.staleness.totalActive).toBe(1);
+      expect(result.staleness.staleCount).toBe(0);
+    });
+  });
+
+  describe('decision density', () => {
+    it('should compute blind spots from repo files not touched by atoms', () => {
+      const atoms = [
+        makeAtom({
+          loreId: 'aaaa1111',
+          filesChanged: ['src/main.ts'],
+        }),
+      ];
+
+      const input: MetricsInput = {
+        atoms,
+        supersessionMap: makeSupersessionMap([['aaaa1111', false, null]]),
+        staleAtomIds: new Set(),
+        totalCommitCount: 1,
+        allRepoFiles: ['src/main.ts', 'src/a.ts', 'src/b.ts', 'src/c.ts'],
+        since: null,
+      };
+
+      const result = collector.collectAll(input);
+
+      expect(result.decisionDensity.uniqueFilesTouched).toBe(1);
+      expect(result.decisionDensity.blindSpotCount).toBe(3);
+      expect(result.decisionDensity.blindSpotFiles).toHaveLength(3);
+      expect(result.decisionDensity.blindSpotFiles).toContain('src/a.ts');
+    });
+
+    it('should cap blind spot files at 10', () => {
+      const atoms = [
+        makeAtom({ loreId: 'aaaa1111', filesChanged: ['src/covered.ts'] }),
+      ];
+
+      const manyFiles = ['src/covered.ts'];
+      for (let i = 0; i < 15; i++) {
+        manyFiles.push(`src/uncovered-${i}.ts`);
+      }
+
+      const input: MetricsInput = {
+        atoms,
+        supersessionMap: makeSupersessionMap([['aaaa1111', false, null]]),
+        staleAtomIds: new Set(),
+        totalCommitCount: 1,
+        allRepoFiles: manyFiles,
+        since: null,
+      };
+
+      const result = collector.collectAll(input);
+
+      expect(result.decisionDensity.blindSpotCount).toBe(15);
+      expect(result.decisionDensity.blindSpotFiles).toHaveLength(10);
+    });
+  });
+
+  describe('period', () => {
+    it('should set since to null when no since is provided', () => {
+      const input: MetricsInput = {
+        atoms: [],
+        supersessionMap: new Map(),
+        staleAtomIds: new Set(),
+        totalCommitCount: 0,
+        allRepoFiles: [],
+        since: null,
+      };
+
+      const result = collector.collectAll(input);
+
+      expect(result.period.since).toBeNull();
+      expect(result.period.analyzedAt).toBeTruthy();
+    });
+
+    it('should set since when provided', () => {
+      const input: MetricsInput = {
+        atoms: [],
+        supersessionMap: new Map(),
+        staleAtomIds: new Set(),
+        totalCommitCount: 0,
+        allRepoFiles: [],
+        since: '2025-01-01',
+      };
+
+      const result = collector.collectAll(input);
+
+      expect(result.period.since).toBe('2025-01-01');
+    });
+  });
+});

--- a/tests/unit/services/metrics-collector.test.ts
+++ b/tests/unit/services/metrics-collector.test.ts
@@ -91,8 +91,8 @@ describe('MetricsCollector', () => {
       expect(result.constraintCoverage.coverageRate).toBe(0);
       expect(result.rejectionLibrary.uniqueRejections).toBe(0);
       expect(result.rejectionLibrary.totalRejectionEntries).toBe(0);
-      expect(result.authorBreakdown.agentCommits).toBe(0);
-      expect(result.authorBreakdown.humanCommits).toBe(0);
+      expect(result.authorBreakdown.agentLoreCommits).toBe(0);
+      expect(result.authorBreakdown.humanLoreCommits).toBe(0);
     });
   });
 
@@ -150,8 +150,8 @@ describe('MetricsCollector', () => {
 
       const result = collector.collectAll(input);
 
-      expect(result.authorBreakdown.agentCommits).toBe(2);
-      expect(result.authorBreakdown.humanCommits).toBe(2);
+      expect(result.authorBreakdown.agentLoreCommits).toBe(2);
+      expect(result.authorBreakdown.humanLoreCommits).toBe(2);
       expect(result.adoption.adoptionRate).toBe(0.4);
     });
 
@@ -177,8 +177,8 @@ describe('MetricsCollector', () => {
 
       const result = collector.collectAll(input);
 
-      expect(result.authorBreakdown.agentCommits).toBe(5);
-      expect(result.authorBreakdown.humanCommits).toBe(0);
+      expect(result.authorBreakdown.agentLoreCommits).toBe(5);
+      expect(result.authorBreakdown.humanLoreCommits).toBe(0);
     });
   });
 
@@ -526,6 +526,112 @@ describe('MetricsCollector', () => {
       const result = collector.collectAll(input);
 
       expect(result.period.since).toBe('2025-01-01');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle circular supersession (A supersedes B, B supersedes A) without infinite loop', () => {
+      const atoms = [
+        makeAtom({ loreId: 'aaaa1111', supersedes: ['bbbb2222'] }),
+        makeAtom({ loreId: 'bbbb2222', supersedes: ['aaaa1111'] }),
+      ];
+
+      const input: MetricsInput = {
+        atoms,
+        supersessionMap: makeSupersessionMap([
+          ['aaaa1111', true, 'bbbb2222'],
+          ['bbbb2222', true, 'aaaa1111'],
+        ]),
+        staleAtomIds: new Set(),
+        totalCommitCount: 2,
+        allRepoFiles: [],
+        since: null,
+      };
+
+      // Should complete without hanging or throwing
+      const result = collector.collectAll(input);
+
+      expect(result.supersessionDepth.totalChains).toBeGreaterThanOrEqual(0);
+      expect(result.supersessionDepth.maxDepth).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should handle adoption rate when atoms exceed totalCommitCount', () => {
+      const atoms = [
+        makeAtom({ loreId: 'aaaa1111' }),
+        makeAtom({ loreId: 'bbbb2222' }),
+        makeAtom({ loreId: 'cccc3333' }),
+      ];
+
+      const input: MetricsInput = {
+        atoms,
+        supersessionMap: makeSupersessionMap([
+          ['aaaa1111', false, null],
+          ['bbbb2222', false, null],
+          ['cccc3333', false, null],
+        ]),
+        staleAtomIds: new Set(),
+        totalCommitCount: 1,
+        allRepoFiles: [],
+        since: null,
+      };
+
+      const result = collector.collectAll(input);
+
+      // Adoption rate exceeds 1.0 when atoms > totalCommitCount
+      expect(result.adoption.adoptionRate).toBe(3);
+      expect(result.adoption.loreCommits).toBe(3);
+      expect(result.adoption.totalCommits).toBe(1);
+    });
+
+    it('should report agentLoreCommits = 0 when all authors are human', () => {
+      const atoms = [
+        makeAtom({ loreId: 'aaaa1111', author: 'alice@company.com' }),
+        makeAtom({ loreId: 'bbbb2222', author: 'bob@company.com' }),
+        makeAtom({ loreId: 'cccc3333', author: 'carol@company.com' }),
+      ];
+
+      const input: MetricsInput = {
+        atoms,
+        supersessionMap: makeSupersessionMap([
+          ['aaaa1111', false, null],
+          ['bbbb2222', false, null],
+          ['cccc3333', false, null],
+        ]),
+        staleAtomIds: new Set(),
+        totalCommitCount: 5,
+        allRepoFiles: [],
+        since: null,
+      };
+
+      const result = collector.collectAll(input);
+
+      expect(result.authorBreakdown.agentLoreCommits).toBe(0);
+      expect(result.authorBreakdown.humanLoreCommits).toBe(3);
+      expect(result.authorBreakdown.agentAdoptionRate).toBe(0);
+      expect(result.authorBreakdown.humanAdoptionRate).toBeGreaterThan(0);
+    });
+
+    it('should handle zero atoms with positive commits without division by zero', () => {
+      const input: MetricsInput = {
+        atoms: [],
+        supersessionMap: new Map(),
+        staleAtomIds: new Set(),
+        totalCommitCount: 100,
+        allRepoFiles: ['src/main.ts', 'src/util.ts'],
+        since: null,
+      };
+
+      const result = collector.collectAll(input);
+
+      expect(result.adoption.adoptionRate).toBe(0);
+      expect(result.adoption.loreCommits).toBe(0);
+      expect(result.adoption.totalCommits).toBe(100);
+      expect(result.decisionDensity.atomsPerFile).toBe(0);
+      expect(result.decisionDensity.blindSpotCount).toBe(2);
+      expect(result.trailerCoverage.totalAtoms).toBe(0);
+      expect(result.authorBreakdown.agentLoreCommits).toBe(0);
+      expect(result.authorBreakdown.humanLoreCommits).toBe(0);
+      expect(result.authorBreakdown.humanAdoptionRate).toBe(0);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Adds `lore metrics` command that computes 8 categories of protocol adoption and health metrics: adoption rate, decision density, trailer coverage, staleness, supersession depth, constraint coverage, rejection library, and author breakdown (agent vs. human).
- Text formatter renders a dashboard with progress bars and an embedded benchmarking guide explaining automatic vs. manual metrics and a before/after comparison framework.
- JSON formatter outputs all metrics in snake_case with a benchmarking guide string, suitable for time-series tracking via `lore metrics --json > metrics-$(date +%Y-%m-%d).json`.

## Changes
- `src/interfaces/git-client.ts` / `src/services/git-client.ts` -- Added `countAllCommits(since?)` and `listTrackedFiles()` to IGitClient.
- `src/types/output.ts` -- Added 11 new metric type interfaces (FormattableMetricsResult and its sub-types).
- `src/interfaces/output-formatter.ts` -- Added `formatMetricsResult` to IOutputFormatter.
- `src/services/metrics-collector.ts` -- New stateless service with pure computation (no I/O). Agent detection via best-effort author pattern matching.
- `src/formatters/text-formatter.ts` -- Dashboard rendering with progress bars and benchmarking guide.
- `src/formatters/json-formatter.ts` -- Standard JSON output with all metrics in snake_case.
- `src/commands/metrics.ts` -- Command registration following existing patterns (register + deps injection).
- `src/main.ts` -- Wired MetricsCommand into the composition root.
- `tests/unit/services/metrics-collector.test.ts` -- 16 tests covering all 8 metric categories plus edge cases (empty repo, 100% adoption, zero atoms, deduplication, chain depth).

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` passes (348 tests, 0 failures)
- [ ] Manual test: `lore metrics` on a repo with Lore commits
- [ ] Manual test: `lore metrics --json` output is valid JSON
- [ ] Manual test: `lore metrics --since 2025-01-01` filters correctly

Lore-id: 0a77a44e

🤖 Generated with [Claude Code](https://claude.com/claude-code)