### PR TITLE
fix(log): accept positional path arguments (#22)

### DIFF
--- a/tests/unit/commands/log.test.ts
+++ b/tests/unit/commands/log.test.ts
@@ -1,20 +1,19 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { Command } from 'commander';
 import { registerLogCommand } from '../../../src/commands/log.js';
 import type { AtomRepository } from '../../../src/services/atom-repository.js';
 import type { SupersessionResolver } from '../../../src/services/supersession-resolver.js';
 import type { IOutputFormatter } from '../../../src/interfaces/output-formatter.js';
 import type { LoreAtom } from '../../../src/types/domain.js';
+import { CustomTrailerCollection } from '../../../src/types/custom-trailer-collection.js';
 
 /**
  * Regression tests for issue #22: `lore log` must accept positional path
- * arguments (`lore log src/foo.ts`) and the historical `--`-pass-through
- * (`lore log -- src/foo.ts`) without erroring out, and must filter atoms
- * to those whose `filesChanged` matches the requested path(s).
+ * arguments (`lore log src/foo.ts`) and the `--` pass-through
+ * (`lore log -- src/foo.ts`), routing to `findByTarget` for git-level
+ * path filtering.
  *
- * Constructed at the command-action layer so we can drive it through
- * Commander's parseAsync the same way the CLI binary does, but with the
- * downstream services mocked so the test stays a unit test.
+ * Driven through Commander's parseAsync with mocked services.
  */
 
 function makeAtom(overrides: Partial<LoreAtom> & { filesChanged: readonly string[] }): LoreAtom {
@@ -38,6 +37,7 @@ function makeAtom(overrides: Partial<LoreAtom> & { filesChanged: readonly string
       Supersedes: [],
       'Depends-on': [],
       Related: [],
+      custom: CustomTrailerCollection.empty(),
     },
     ...overrides,
   };
@@ -45,25 +45,15 @@ function makeAtom(overrides: Partial<LoreAtom> & { filesChanged: readonly string
 
 interface Harness {
   program: Command;
-  atomRepository: AtomRepository;
-  supersessionResolver: SupersessionResolver;
-  getFormatter: () => IOutputFormatter;
   capturedResult: { data: unknown };
-  formatQueryResult: ReturnType<typeof vi.fn>;
   findAll: ReturnType<typeof vi.fn>;
   findByTarget: ReturnType<typeof vi.fn>;
-  log: ReturnType<typeof vi.spyOn>;
+  consoleSpy: ReturnType<typeof vi.spyOn>;
 }
 
 function buildHarness(atoms: LoreAtom[], filteredAtoms?: LoreAtom[]): Harness {
-  // `lore log` without paths goes through findAll; with paths it routes
-  // through findByTarget (git-level path filtering, see #24). The harness
-  // returns the same atoms either way unless the caller passes a separate
-  // filtered set for the path-filtered branch.
   const findAll = vi.fn().mockResolvedValue(atoms);
-  const findByTarget = vi
-    .fn()
-    .mockResolvedValue(filteredAtoms ?? atoms);
+  const findByTarget = vi.fn().mockResolvedValue(filteredAtoms ?? atoms);
   const atomRepository = { findAll, findByTarget } as unknown as AtomRepository;
 
   const supersessionResolver = {
@@ -86,7 +76,7 @@ function buildHarness(atoms: LoreAtom[], filteredAtoms?: LoreAtom[]): Harness {
     formatError: vi.fn(),
   } as IOutputFormatter;
 
-  const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
   const program = new Command();
   program.exitOverride();
@@ -96,27 +86,12 @@ function buildHarness(atoms: LoreAtom[], filteredAtoms?: LoreAtom[]): Harness {
     getFormatter: () => formatter,
   });
 
-  return {
-    program,
-    atomRepository,
-    supersessionResolver,
-    getFormatter: () => formatter,
-    capturedResult,
-    formatQueryResult,
-    findAll,
-    findByTarget,
-    log,
-  };
+  return { program, capturedResult, findAll, findByTarget, consoleSpy };
 }
 
-// process.argv determines the `--` pass-through inside the action body.
-// Vitest gives each test a fresh sandbox but not a fresh argv, so reset
-// it explicitly around each case.
-const ORIGINAL_ARGV = process.argv;
-
 describe('registerLogCommand (issue #22 path arguments)', () => {
-  beforeEach(() => {
-    process.argv = [...ORIGINAL_ARGV];
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it('accepts a positional path and routes through findByTarget', async () => {
@@ -124,11 +99,9 @@ describe('registerLogCommand (issue #22 path arguments)', () => {
       loreId: 'match0001',
       filesChanged: ['src/main.ts'],
     });
-    // No filtered set passed — findByTarget returns the matching atom.
     const h = buildHarness([matching], [matching]);
 
-    process.argv = ['node', 'lore', 'log', 'src/main.ts'];
-    await h.program.parseAsync(process.argv);
+    await h.program.parseAsync(['node', 'lore', 'log', 'src/main.ts']);
 
     expect(h.findByTarget).toHaveBeenCalledTimes(1);
     expect(h.findByTarget).toHaveBeenCalledWith(
@@ -140,18 +113,16 @@ describe('registerLogCommand (issue #22 path arguments)', () => {
     const result = (h.capturedResult.data as { result: { atoms: LoreAtom[] } }).result;
     expect(result.atoms).toHaveLength(1);
     expect(result.atoms[0].loreId).toBe('match0001');
-    h.log.mockRestore();
   });
 
-  it('accepts the historical `--` pass-through and routes identically', async () => {
+  it('accepts the `--` pass-through and routes identically', async () => {
     const matching = makeAtom({
       loreId: 'match0002',
       filesChanged: ['src/main.ts'],
     });
     const h = buildHarness([matching], [matching]);
 
-    process.argv = ['node', 'lore', 'log', '--', 'src/main.ts'];
-    await h.program.parseAsync(process.argv);
+    await h.program.parseAsync(['node', 'lore', 'log', '--', 'src/main.ts']);
 
     expect(h.findByTarget).toHaveBeenCalledTimes(1);
     expect(h.findByTarget).toHaveBeenCalledWith(
@@ -162,7 +133,6 @@ describe('registerLogCommand (issue #22 path arguments)', () => {
     const result = (h.capturedResult.data as { result: { atoms: LoreAtom[] } }).result;
     expect(result.atoms).toHaveLength(1);
     expect(result.atoms[0].loreId).toBe('match0002');
-    h.log.mockRestore();
   });
 
   it('uses findAll (not findByTarget) when no path argument is provided', async () => {
@@ -170,15 +140,13 @@ describe('registerLogCommand (issue #22 path arguments)', () => {
     const b = makeAtom({ loreId: 'all00002', filesChanged: ['src/b.ts'] });
     const h = buildHarness([a, b]);
 
-    process.argv = ['node', 'lore', 'log'];
-    await h.program.parseAsync(process.argv);
+    await h.program.parseAsync(['node', 'lore', 'log']);
 
     expect(h.findAll).toHaveBeenCalledTimes(1);
     expect(h.findByTarget).not.toHaveBeenCalled();
 
     const result = (h.capturedResult.data as { result: { atoms: LoreAtom[] } }).result;
     expect(result.atoms).toHaveLength(2);
-    h.log.mockRestore();
   });
 
   it('combines --limit with a positional path argument (limit applied client-side)', async () => {
@@ -186,20 +154,42 @@ describe('registerLogCommand (issue #22 path arguments)', () => {
     const b = makeAtom({ loreId: 'limit002', filesChanged: ['src/main.ts'] });
     const h = buildHarness([], [a, b]);
 
-    process.argv = ['node', 'lore', 'log', '--limit', '1', 'src/main.ts'];
-    await h.program.parseAsync(process.argv);
+    await h.program.parseAsync(['node', 'lore', 'log', '--limit', '1', 'src/main.ts']);
 
-    // Path arg routes to findByTarget regardless of --limit.
     expect(h.findByTarget).toHaveBeenCalledTimes(1);
     expect(h.findByTarget).toHaveBeenCalledWith(
       ['--', 'src/main.ts'],
       expect.any(Object),
     );
 
-    // --limit truncates the formatted result client-side.
     const result = (h.capturedResult.data as { result: { atoms: LoreAtom[] } }).result;
     expect(result.atoms).toHaveLength(1);
     expect(result.atoms[0].loreId).toBe('limit001');
-    h.log.mockRestore();
+  });
+
+  it('passes --max-commits to findByTarget as maxCommits in PathQueryOptions', async () => {
+    const atom = makeAtom({ loreId: 'mc000001', filesChanged: ['src/main.ts'] });
+    const h = buildHarness([], [atom]);
+
+    await h.program.parseAsync(['node', 'lore', 'log', '--max-commits', '50', 'src/main.ts']);
+
+    const queryOptions = h.findByTarget.mock.calls[0][1];
+    expect(queryOptions.maxCommits).toBe(50);
+  });
+
+  it('reflects totalAtoms before --limit in meta', async () => {
+    const atoms = [
+      makeAtom({ loreId: 'meta0001', filesChanged: ['src/a.ts'] }),
+      makeAtom({ loreId: 'meta0002', filesChanged: ['src/b.ts'] }),
+      makeAtom({ loreId: 'meta0003', filesChanged: ['src/c.ts'] }),
+    ];
+    const h = buildHarness(atoms);
+
+    await h.program.parseAsync(['node', 'lore', 'log', '--limit', '1']);
+
+    const data = h.capturedResult.data as { result: { atoms: LoreAtom[]; meta: { totalAtoms: number; filteredAtoms: number } } };
+    expect(data.result.meta.totalAtoms).toBe(3);
+    expect(data.result.meta.filteredAtoms).toBe(1);
+    expect(data.result.atoms).toHaveLength(1);
   });
 });

--- a/tests/unit/commands/log.test.ts
+++ b/tests/unit/commands/log.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Command } from 'commander';
+import { registerLogCommand } from '../../../src/commands/log.js';
+import type { AtomRepository } from '../../../src/services/atom-repository.js';
+import type { SupersessionResolver } from '../../../src/services/supersession-resolver.js';
+import type { IOutputFormatter } from '../../../src/interfaces/output-formatter.js';
+import type { LoreAtom } from '../../../src/types/domain.js';
+
+/**
+ * Regression tests for issue #22: `lore log` must accept positional path
+ * arguments (`lore log src/foo.ts`) and the historical `--`-pass-through
+ * (`lore log -- src/foo.ts`) without erroring out, and must filter atoms
+ * to those whose `filesChanged` matches the requested path(s).
+ *
+ * Constructed at the command-action layer so we can drive it through
+ * Commander's parseAsync the same way the CLI binary does, but with the
+ * downstream services mocked so the test stays a unit test.
+ */
+
+function makeAtom(overrides: Partial<LoreAtom> & { filesChanged: readonly string[] }): LoreAtom {
+  return {
+    loreId: 'abcd1234',
+    commitHash: 'a'.repeat(40),
+    date: new Date('2026-01-01T00:00:00Z'),
+    author: 'Tester <tester@example.com>',
+    intent: 'fix: example',
+    body: '',
+    trailers: {
+      'Lore-id': 'abcd1234',
+      Constraint: [],
+      Rejected: [],
+      Confidence: null,
+      'Scope-risk': null,
+      Reversibility: null,
+      Directive: [],
+      Tested: [],
+      'Not-tested': [],
+      Supersedes: [],
+      'Depends-on': [],
+      Related: [],
+    },
+    ...overrides,
+  };
+}
+
+interface Harness {
+  program: Command;
+  atomRepository: AtomRepository;
+  supersessionResolver: SupersessionResolver;
+  getFormatter: () => IOutputFormatter;
+  capturedResult: { data: unknown };
+  formatQueryResult: ReturnType<typeof vi.fn>;
+  findAll: ReturnType<typeof vi.fn>;
+  findByTarget: ReturnType<typeof vi.fn>;
+  log: ReturnType<typeof vi.spyOn>;
+}
+
+function buildHarness(atoms: LoreAtom[], filteredAtoms?: LoreAtom[]): Harness {
+  // `lore log` without paths goes through findAll; with paths it routes
+  // through findByTarget (git-level path filtering, see #24). The harness
+  // returns the same atoms either way unless the caller passes a separate
+  // filtered set for the path-filtered branch.
+  const findAll = vi.fn().mockResolvedValue(atoms);
+  const findByTarget = vi
+    .fn()
+    .mockResolvedValue(filteredAtoms ?? atoms);
+  const atomRepository = { findAll, findByTarget } as unknown as AtomRepository;
+
+  const supersessionResolver = {
+    resolve: vi.fn().mockReturnValue(new Map()),
+  } as unknown as SupersessionResolver;
+
+  const capturedResult: { data: unknown } = { data: undefined };
+  const formatQueryResult = vi.fn((data: unknown) => {
+    capturedResult.data = data;
+    return '';
+  });
+
+  const formatter = {
+    formatQueryResult,
+    formatValidationResult: vi.fn(),
+    formatStalenessResult: vi.fn(),
+    formatTraceResult: vi.fn(),
+    formatDoctorResult: vi.fn(),
+    formatSuccess: vi.fn(),
+    formatError: vi.fn(),
+  } as IOutputFormatter;
+
+  const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+  const program = new Command();
+  program.exitOverride();
+  registerLogCommand(program, {
+    atomRepository,
+    supersessionResolver,
+    getFormatter: () => formatter,
+  });
+
+  return {
+    program,
+    atomRepository,
+    supersessionResolver,
+    getFormatter: () => formatter,
+    capturedResult,
+    formatQueryResult,
+    findAll,
+    findByTarget,
+    log,
+  };
+}
+
+// process.argv determines the `--` pass-through inside the action body.
+// Vitest gives each test a fresh sandbox but not a fresh argv, so reset
+// it explicitly around each case.
+const ORIGINAL_ARGV = process.argv;
+
+describe('registerLogCommand (issue #22 path arguments)', () => {
+  beforeEach(() => {
+    process.argv = [...ORIGINAL_ARGV];
+  });
+
+  it('accepts a positional path and routes through findByTarget', async () => {
+    const matching = makeAtom({
+      loreId: 'match0001',
+      filesChanged: ['src/main.ts'],
+    });
+    // No filtered set passed — findByTarget returns the matching atom.
+    const h = buildHarness([matching], [matching]);
+
+    process.argv = ['node', 'lore', 'log', 'src/main.ts'];
+    await h.program.parseAsync(process.argv);
+
+    expect(h.findByTarget).toHaveBeenCalledTimes(1);
+    expect(h.findByTarget).toHaveBeenCalledWith(
+      ['--', 'src/main.ts'],
+      expect.any(Object),
+    );
+    expect(h.findAll).not.toHaveBeenCalled();
+
+    const result = (h.capturedResult.data as { result: { atoms: LoreAtom[] } }).result;
+    expect(result.atoms).toHaveLength(1);
+    expect(result.atoms[0].loreId).toBe('match0001');
+    h.log.mockRestore();
+  });
+
+  it('accepts the historical `--` pass-through and routes identically', async () => {
+    const matching = makeAtom({
+      loreId: 'match0002',
+      filesChanged: ['src/main.ts'],
+    });
+    const h = buildHarness([matching], [matching]);
+
+    process.argv = ['node', 'lore', 'log', '--', 'src/main.ts'];
+    await h.program.parseAsync(process.argv);
+
+    expect(h.findByTarget).toHaveBeenCalledTimes(1);
+    expect(h.findByTarget).toHaveBeenCalledWith(
+      ['--', 'src/main.ts'],
+      expect.any(Object),
+    );
+
+    const result = (h.capturedResult.data as { result: { atoms: LoreAtom[] } }).result;
+    expect(result.atoms).toHaveLength(1);
+    expect(result.atoms[0].loreId).toBe('match0002');
+    h.log.mockRestore();
+  });
+
+  it('uses findAll (not findByTarget) when no path argument is provided', async () => {
+    const a = makeAtom({ loreId: 'all00001', filesChanged: ['src/a.ts'] });
+    const b = makeAtom({ loreId: 'all00002', filesChanged: ['src/b.ts'] });
+    const h = buildHarness([a, b]);
+
+    process.argv = ['node', 'lore', 'log'];
+    await h.program.parseAsync(process.argv);
+
+    expect(h.findAll).toHaveBeenCalledTimes(1);
+    expect(h.findByTarget).not.toHaveBeenCalled();
+
+    const result = (h.capturedResult.data as { result: { atoms: LoreAtom[] } }).result;
+    expect(result.atoms).toHaveLength(2);
+    h.log.mockRestore();
+  });
+
+  it('combines --limit with a positional path argument (limit applied client-side)', async () => {
+    const a = makeAtom({ loreId: 'limit001', filesChanged: ['src/main.ts'] });
+    const b = makeAtom({ loreId: 'limit002', filesChanged: ['src/main.ts'] });
+    const h = buildHarness([], [a, b]);
+
+    process.argv = ['node', 'lore', 'log', '--limit', '1', 'src/main.ts'];
+    await h.program.parseAsync(process.argv);
+
+    // Path arg routes to findByTarget regardless of --limit.
+    expect(h.findByTarget).toHaveBeenCalledTimes(1);
+    expect(h.findByTarget).toHaveBeenCalledWith(
+      ['--', 'src/main.ts'],
+      expect.any(Object),
+    );
+
+    // --limit truncates the formatted result client-side.
+    const result = (h.capturedResult.data as { result: { atoms: LoreAtom[] } }).result;
+    expect(result.atoms).toHaveLength(1);
+    expect(result.atoms[0].loreId).toBe('limit001');
+    h.log.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

\`lore log\` claimed to be a *Lore-enriched git log* but rejected \`lore log src/main.ts\` with:

\`\`\`
error: too many arguments for 'log'. Expected 0 arguments but got 1.
\`\`\`

The action handler already used path arguments (read out of \`process.argv\` after a \`--\` separator) but the commander registration never declared the positional argument, so commander rejected the call before our code ran.

## Fix

- Add \`.argument('[paths...]')\` so \`commander\` accepts \`lore log <path> [<path> …]\` directly.
- Take the new array as the first parameter to the action callback, then merge it with whatever still arrives after \`--\`.

Both call shapes now work:

\`\`\`
lore log src/main.ts
lore log -- src/main.ts
\`\`\`

Behaviour for \`lore log\` (no paths) and \`--limit\` / \`--since\` is unchanged.

Fixes #22

## Test plan

- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm test\` — 18 files / 332 tests, all passing