### PR TITLE
Fix: read --version from package.json (closes #27)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,8 @@
 import { Command } from 'commander';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { version } = require('../package.json') as { version: string };
 
 import type { IGitClient } from './interfaces/git-client.js';
 import type { IConfigLoader } from './interfaces/config-loader.js';
@@ -53,7 +57,7 @@ async function main(): Promise<void> {
   program
     .name('lore')
     .description('CLI tool for the Lore protocol -- structured decision context in git commits')
-    .version('0.1.0');
+    .version(version);
 
   // Global options
   program

--- a/tests/unit/version.test.ts
+++ b/tests/unit/version.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(__dirname, '..', '..');
+
+const require = createRequire(import.meta.url);
+const { version } = require('../../package.json') as { version: string };
+
+describe('--version flag', () => {
+  it('should match package.json version', () => {
+    const output = execFileSync(process.execPath, ['dist/main.js', '--version'], {
+      cwd: projectRoot,
+      encoding: 'utf-8',
+    }).trim();
+
+    expect(output).toBe(version);
+  });
+});


### PR DESCRIPTION
## Summary
- `lore --version` was hardcoded as `'0.1.0'` in `main.ts`
- Now reads dynamically from `package.json` via `createRequire`
- Reported by @c-ferrier in #27

## Test plan
- [x] `lore --version` returns `0.2.0` (matches package.json)
- [x] 372 tests pass
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)