### PR TITLE
Add manual trigger to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: Publish to npm
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   publish:


### PR DESCRIPTION
## Summary

- Add `workflow_dispatch` trigger to the publish workflow so it can be run manually from the Actions tab

## Test plan

- [ ] CI passes
- [ ] After merge, "Run workflow" button appears on the Publish workflow in Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)