### PR TITLE
Use npm OIDC trusted publishing (no NPM_TOKEN needed)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,5 +28,3 @@ jobs:
       - run: npm test
 
       - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- Remove `NPM_TOKEN` secret from publish workflow
- npm authenticates via GitHub's OIDC token exchange instead of a static secret
- `id-token: write` permission and `--provenance` flag were already in place

## Prerequisites

Before merging, configure trusted publishing on npmjs.com:

1. Go to **npmjs.com** > `lore-protocol` package > **Settings** > **Trusted Publishing**
2. Add trusted publisher:
   - Repository owner: `Ian-stetsenko`
   - Repository name: `lore-protocol`
   - Workflow filename: `publish.yml`
   - Environment: _(leave blank)_

## Test plan

- [ ] Configure trusted publisher on npmjs.com
- [ ] Merge this PR
- [ ] Run publish workflow manually — should authenticate via OIDC and publish successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)