### PR TITLE
Fix publish workflow to match npm OIDC spec

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,12 +5,13 @@ on:
     types: [published]
   workflow_dispatch:
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@v4
 
@@ -27,4 +28,4 @@ jobs:
 
       - run: npm test
 
-      - run: npm publish --provenance --access public
+      - run: npm publish


### PR DESCRIPTION
## Summary

- Move `permissions` to workflow top level (not job level) — npm OIDC requires this
- Remove `--provenance` and `--access public` flags — handled automatically by OIDC

## Changes
- `permissions.id-token: write` moved from job to workflow level
- `npm publish` with no extra flags

## Test plan

- [ ] Merge and run publish workflow manually
- [ ] npm should authenticate via OIDC and publish 0.3.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)