### PR TITLE
Fix publish: upgrade to setup-node@v6 for OIDC support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,11 +13,11 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - run: npm ci


### PR DESCRIPTION
## Summary

- Upgrade `actions/checkout` v4 → v6 and `actions/setup-node` v4 → v6
- `setup-node@v4` doesn't support npm OIDC token exchange — it was sending the `GITHUB_TOKEN` to npm, causing 404 errors
- `setup-node@v6` handles OIDC natively, matching the npm trusted publishing docs
- Node.js version bumped to 24 (matching npm's example)

## Test plan

- [ ] Merge and run publish workflow — should authenticate via OIDC and publish 0.3.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)