### PR TITLE
Add repository URL to package.json (fixes npm provenance)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "lore-protocol",
   "version": "0.3.0",
   "description": "CLI tool for the Lore protocol — structured decision context in git commits",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Ian-stetsenko/lore-protocol"
+  },
   "type": "module",
   "bin": {
     "lore": "./bin/lore.js"


### PR DESCRIPTION
## Summary

- Add `repository.url` to package.json pointing to `https://github.com/Ian-stetsenko/lore-protocol`
- npm's OIDC provenance verification requires this field to match the GitHub repo in the sigstore bundle
- Without it, publish fails with `E422: "repository.url" is "", expected to match "https://github.com/Ian-stetsenko/lore-protocol"`

## Test plan

- [ ] Merge and run publish workflow — should publish 0.3.0 to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)