### PR TITLE
CI: only run on PRs, not on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   pull_request:
     branches: [main]
-  push:
-    branches: [main]
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

- Remove `push: branches: [main]` trigger from CI workflow
- CI was running twice on every merge — once on the PR, once on the merge commit
- Branch protection ensures all changes go through PRs, so the push trigger is redundant

## Test plan

- [ ] CI runs on this PR
- [ ] After merge, no CI run triggers on the merge commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)