### PR TITLE
fix: strip trailers from body when no narrative paragraph exists

### DIFF
--- a/src/services/atom-repository.ts
+++ b/src/services/atom-repository.ts
@@ -260,7 +260,7 @@ export class AtomRepository {
     // Try to find the first trailer line in the body and strip from there
     const firstTrailerLine = trailerLines[0].trim();
     const idx = body.lastIndexOf(firstTrailerLine);
-    if (idx > 0) {
+    if (idx >= 0) {
       return body.slice(0, idx).trim();
     }
 

--- a/tests/unit/services/atom-repository.test.ts
+++ b/tests/unit/services/atom-repository.test.ts
@@ -296,6 +296,25 @@ describe('AtomRepository', () => {
       expect(result).toHaveLength(2);
     });
 
+    it('should strip trailers from body when body is exactly the trailer block', async () => {
+      const trailersRaw = 'Lore-id: aaaa1111\nDirective: keep simple';
+      const commit: RawCommit = {
+        hash: 'aaa',
+        date: '2025-01-15T10:00:00Z',
+        author: 'dev@example.com',
+        subject: 'feat: no body',
+        body: trailersRaw,
+        trailers: trailersRaw,
+      };
+      vi.mocked(gitClient.log).mockResolvedValue([commit]);
+      vi.mocked(gitClient.getFilesChanged).mockResolvedValue([]);
+
+      const result = await repo.findAll();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].body).toBe('');
+    });
+
     it('should pass since option to git log', async () => {
       vi.mocked(gitClient.log).mockResolvedValue([]);
 


### PR DESCRIPTION
Corrects duplication in text output for commits where the trailer block starts at index 0. This typically happens when a commit has no narrative body paragraph. Fixes #43.