### PR TITLE
Fix: error when --no-edit is combined with input (closes #48)

### DIFF
--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -56,6 +56,13 @@ export function registerCommitCommand(
 
       // --amend --no-edit: pass through to git, no Lore processing
       if (options.amend && options.edit === false) {
+        const hasInputFlags = options.file || options.interactive || options.intent || process.stdin.isTTY === false;
+        if (hasInputFlags) {
+          throw new LoreError(
+            '--no-edit keeps the existing message unchanged. Remove --no-edit to update trailers, or remove the input flags/payload to keep the message as-is.',
+            1,
+          );
+        }
         const result = await gitClient.commit('', { amend: true, noEdit: true });
         console.log(formatter.formatSuccess(`Commit amended: ${result.hash}`, { hash: result.hash }));
         return;

--- a/tests/unit/commands/commit-amend.test.ts
+++ b/tests/unit/commands/commit-amend.test.ts
@@ -131,6 +131,30 @@ describe('lore commit --amend', () => {
     );
   });
 
+  it('should throw when --no-edit is combined with --file', async () => {
+    const deps = createDeps();
+
+    await expect(
+      runCommitCommand(['--amend', '--no-edit', '--file', 'input.json'], deps),
+    ).rejects.toThrow('--no-edit keeps the existing message unchanged');
+  });
+
+  it('should throw when --no-edit is combined with --intent', async () => {
+    const deps = createDeps();
+
+    await expect(
+      runCommitCommand(['--amend', '--no-edit', '--intent', 'new intent'], deps),
+    ).rejects.toThrow('--no-edit keeps the existing message unchanged');
+  });
+
+  it('should throw when --no-edit is combined with --interactive', async () => {
+    const deps = createDeps();
+
+    await expect(
+      runCommitCommand(['--amend', '--no-edit', '-i'], deps),
+    ).rejects.toThrow('--no-edit keeps the existing message unchanged');
+  });
+
   it('should throw when --no-edit is used without --amend', async () => {
     const deps = createDeps();
 


### PR DESCRIPTION
## Summary

When `--amend --no-edit` was combined with `--file`, `--intent`, `-i`, or piped JSON stdin, the input was silently discarded. The commit message stayed unchanged with no warning — the user (or agent) thinks they updated trailers but nothing happened.

Now throws an actionable error:
```
--no-edit keeps the existing message unchanged. Remove --no-edit to update
trailers, or remove the input flags/payload to keep the message as-is.
```

Reported by @c-ferrier in #48 — discovered when Gemini CLI combined `--no-edit` with a JSON payload.

## Changes
- `src/commands/commit.ts` — detect conflicting input flags/piped stdin before the `--no-edit` passthrough
- `tests/unit/commands/commit-amend.test.ts` — 3 new tests for `--file`, `--intent`, `-i` conflicts

## Test plan
- [x] `--amend --no-edit` alone still works (passthrough)
- [x] `--amend --no-edit --file` throws
- [x] `--amend --no-edit --intent` throws
- [x] `--amend --no-edit -i` throws
- [x] 410 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)