### PR TITLE
fix: detect heredoc/stdin conflict with --amend --no-edit

### DIFF
--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -56,6 +56,18 @@ export function registerCommitCommand(
 
       // --amend --no-edit: pass through to git, no Lore processing
       if (options.amend && options.edit === false) {
+        const INPUT_FLAG_KEYS: ReadonlyArray<keyof CommitCommandOptions> = [
+          'file', 'interactive', 'intent', 'body', 'constraint', 'rejected',
+          'confidence', 'scopeRisk', 'reversibility', 'directive', 'tested',
+          'notTested', 'supersedes', 'dependsOn', 'related',
+        ];
+        const hasInputFlags = INPUT_FLAG_KEYS.some(k => options[k] !== undefined) || !process.stdin.isTTY;
+        if (hasInputFlags) {
+          throw new LoreError(
+            '--no-edit keeps the existing message unchanged. Remove --no-edit to update trailers, or remove the input flags/payload to keep the message as-is.',
+            1,
+          );
+        }
         const result = await gitClient.commit('', { amend: true, noEdit: true });
         console.log(formatter.formatSuccess(`Commit amended: ${result.hash}`, { hash: result.hash }));
         return;

--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -6,6 +6,20 @@ import type { CommitInputResolver, CommitCommandOptions } from '../services/comm
 import type { HeadLoreIdReader } from '../services/head-lore-id-reader.js';
 import { LoreError, NoStagedChangesError, ValidationError } from '../util/errors.js';
 
+/** Keys on CommitCommandOptions that are NOT user-supplied input. */
+const NON_INPUT_KEYS: ReadonlySet<string> = new Set(['amend', 'edit']);
+
+/**
+ * Detect conflicting input when --no-edit is used.
+ * Uses exclusion: anything in options that is NOT amend/edit is user input.
+ * New flags are caught automatically — no maintenance list to update.
+ */
+function hasConflictingInput(options: CommitCommandOptions): boolean {
+  return Object.entries(options)
+    .filter(([k]) => !NON_INPUT_KEYS.has(k))
+    .some(([, v]) => v !== undefined);
+}
+
 /**
  * Register the `lore commit` command.
  * Default: read JSON from stdin.
@@ -56,13 +70,7 @@ export function registerCommitCommand(
 
       // --amend --no-edit: pass through to git, no Lore processing
       if (options.amend && options.edit === false) {
-        const INPUT_FLAG_KEYS: ReadonlyArray<keyof CommitCommandOptions> = [
-          'file', 'interactive', 'intent', 'body', 'constraint', 'rejected',
-          'confidence', 'scopeRisk', 'reversibility', 'directive', 'tested',
-          'notTested', 'supersedes', 'dependsOn', 'related',
-        ];
-        const hasInputFlags = INPUT_FLAG_KEYS.some(k => options[k] !== undefined) || !process.stdin.isTTY;
-        if (hasInputFlags) {
+        if (hasConflictingInput(options)) {
           throw new LoreError(
             '--no-edit keeps the existing message unchanged. Remove --no-edit to update trailers, or remove the input flags/payload to keep the message as-is.',
             1,

--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -12,12 +12,20 @@ const NON_INPUT_KEYS: ReadonlySet<string> = new Set(['amend', 'edit']);
 /**
  * Detect conflicting input when --no-edit is used.
  * Uses exclusion: anything in options that is NOT amend/edit is user input.
- * New flags are caught automatically — no maintenance list to update.
+ * Also detects piped stdin (heredoc) when not in a TTY.
  */
 function hasConflictingInput(options: CommitCommandOptions): boolean {
-  return Object.entries(options)
+  const hasFlagInput = Object.entries(options)
     .filter(([k]) => !NON_INPUT_KEYS.has(k))
     .some(([, v]) => v !== undefined);
+
+  if (hasFlagInput) {
+    return true;
+  }
+
+  // If stdin is not a TTY, lore defaults to reading from it.
+  // This conflicts with --no-edit.
+  return !process.stdin.isTTY;
 }
 
 /**

--- a/tests/unit/commands/commit-amend.test.ts
+++ b/tests/unit/commands/commit-amend.test.ts
@@ -119,11 +119,8 @@ describe('lore commit --amend', () => {
 
   it('should bypass Lore processing with --amend --no-edit', async () => {
     const deps = createDeps();
-    const originalIsTTY = process.stdin.isTTY;
-    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
 
-    try {
-      await runCommitCommand(['--amend', '--no-edit'], deps);
+    await runCommitCommand(['--amend', '--no-edit'], deps);
 
     expect(deps.commitInputResolver.resolve).not.toHaveBeenCalled();
     expect(deps.commitBuilder.build).not.toHaveBeenCalled();
@@ -132,9 +129,6 @@ describe('lore commit --amend', () => {
       '',
       { amend: true, noEdit: true },
     );
-    } finally {
-      Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true });
-    }
   });
 
   it('should throw when --no-edit is combined with --file', async () => {
@@ -169,6 +163,20 @@ describe('lore commit --amend', () => {
     const deps = createDeps();
     await expect(
       runCommitCommand(['--amend', '--no-edit', '--constraint', 'must use X'], deps),
+    ).rejects.toThrow('--no-edit keeps the existing message unchanged');
+  });
+
+  it('should throw when --no-edit is combined with enum trailer flags', async () => {
+    const deps = createDeps();
+    await expect(
+      runCommitCommand(['--amend', '--no-edit', '--confidence', 'high'], deps),
+    ).rejects.toThrow('--no-edit keeps the existing message unchanged');
+  });
+
+  it('should throw when --no-edit is combined with reference trailer flags', async () => {
+    const deps = createDeps();
+    await expect(
+      runCommitCommand(['--amend', '--no-edit', '--related', 'abc12345'], deps),
     ).rejects.toThrow('--no-edit keeps the existing message unchanged');
   });
 

--- a/tests/unit/commands/commit-amend.test.ts
+++ b/tests/unit/commands/commit-amend.test.ts
@@ -119,8 +119,11 @@ describe('lore commit --amend', () => {
 
   it('should bypass Lore processing with --amend --no-edit', async () => {
     const deps = createDeps();
+    const originalIsTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
 
-    await runCommitCommand(['--amend', '--no-edit'], deps);
+    try {
+      await runCommitCommand(['--amend', '--no-edit'], deps);
 
     expect(deps.commitInputResolver.resolve).not.toHaveBeenCalled();
     expect(deps.commitBuilder.build).not.toHaveBeenCalled();
@@ -129,6 +132,44 @@ describe('lore commit --amend', () => {
       '',
       { amend: true, noEdit: true },
     );
+    } finally {
+      Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true });
+    }
+  });
+
+  it('should throw when --no-edit is combined with --file', async () => {
+    const deps = createDeps();
+    await expect(
+      runCommitCommand(['--amend', '--no-edit', '--file', 'input.json'], deps),
+    ).rejects.toThrow('--no-edit keeps the existing message unchanged');
+  });
+
+  it('should throw when --no-edit is combined with --intent', async () => {
+    const deps = createDeps();
+    await expect(
+      runCommitCommand(['--amend', '--no-edit', '--intent', 'new'], deps),
+    ).rejects.toThrow('--no-edit keeps the existing message unchanged');
+  });
+
+  it('should throw when --no-edit is combined with --interactive', async () => {
+    const deps = createDeps();
+    await expect(
+      runCommitCommand(['--amend', '--no-edit', '-i'], deps),
+    ).rejects.toThrow('--no-edit keeps the existing message unchanged');
+  });
+
+  it('should throw when --no-edit is combined with --body', async () => {
+    const deps = createDeps();
+    await expect(
+      runCommitCommand(['--amend', '--no-edit', '--body', 'some context'], deps),
+    ).rejects.toThrow('--no-edit keeps the existing message unchanged');
+  });
+
+  it('should throw when --no-edit is combined with trailer flags', async () => {
+    const deps = createDeps();
+    await expect(
+      runCommitCommand(['--amend', '--no-edit', '--constraint', 'must use X'], deps),
+    ).rejects.toThrow('--no-edit keeps the existing message unchanged');
   });
 
   it('should throw when --no-edit is used without --amend', async () => {

--- a/tests/unit/commands/commit-amend.test.ts
+++ b/tests/unit/commands/commit-amend.test.ts
@@ -119,16 +119,36 @@ describe('lore commit --amend', () => {
 
   it('should bypass Lore processing with --amend --no-edit', async () => {
     const deps = createDeps();
+    const originalIsTTY = process.stdin.isTTY;
+    process.stdin.isTTY = true;
 
-    await runCommitCommand(['--amend', '--no-edit'], deps);
+    try {
+      await runCommitCommand(['--amend', '--no-edit'], deps);
 
-    expect(deps.commitInputResolver.resolve).not.toHaveBeenCalled();
-    expect(deps.commitBuilder.build).not.toHaveBeenCalled();
-    expect(deps.commitBuilder.validate).not.toHaveBeenCalled();
-    expect(deps.gitClient.commit).toHaveBeenCalledWith(
-      '',
-      { amend: true, noEdit: true },
-    );
+      expect(deps.commitInputResolver.resolve).not.toHaveBeenCalled();
+      expect(deps.commitBuilder.build).not.toHaveBeenCalled();
+      expect(deps.commitBuilder.validate).not.toHaveBeenCalled();
+      expect(deps.gitClient.commit).toHaveBeenCalledWith(
+        '',
+        { amend: true, noEdit: true },
+      );
+    } finally {
+      process.stdin.isTTY = originalIsTTY;
+    }
+  });
+
+  it('should throw when --no-edit is combined with piped stdin', async () => {
+    const deps = createDeps();
+    const originalIsTTY = process.stdin.isTTY;
+    process.stdin.isTTY = false; // Simulate piped input
+
+    try {
+      await expect(
+        runCommitCommand(['--amend', '--no-edit'], deps),
+      ).rejects.toThrow('--no-edit keeps the existing message unchanged');
+    } finally {
+      process.stdin.isTTY = originalIsTTY;
+    }
   });
 
   it('should throw when --no-edit is combined with --file', async () => {


### PR DESCRIPTION
## Summary
This PR improves the conflict detection introduced in #50 to include piped stdin (heredoc) payloads.

### The Problem
While #50 correctly identified conflicts between `--no-edit` and explicit data flags (like `--intent`), it missed the standard Lore workflow where JSON is piped via stdin:

```bash
# This would still silently ignore the JSON payload in #50
lore commit --amend --no-edit <<EOF
{ "intent": "new intent" }
EOF
```

### The Fix
Updated `hasConflictingInput` in `src/commands/commit.ts` to check if `process.stdin.isTTY` is false. When Lore is receiving piped data, it now correctly identifies this as a conflict with `--no-edit` and throws an actionable error, preventing silent data loss.

### Changes
- **src/commands/commit.ts**: Added TTY check to `hasConflictingInput`.
- **tests/unit/commands/commit-amend.test.ts**: 
    - Added a new unit test for non-TTY stdin conflicts.
    - Updated the standard bypass test to mock TTY state, ensuring it only bypasses when truly intended.

### Verification
- [x] All 415 unit tests pass.
- [x] Verified manually that `echo '{}' | lore commit --amend --no-edit` fails.
- [x] Verified manually that `lore commit --amend --no-edit` (in a terminal) still works as a standard Git pass-through.

Related to #50 and #48.