### PR TITLE
feat(search): implement custom trailer support in search and display

### DIFF
--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -6,9 +6,12 @@ import type { IOutputFormatter } from '../interfaces/output-formatter.js';
 import type { TrailerKey, LoreAtom, SupersessionStatus } from '../types/domain.js';
 import type { SearchOptions, QueryResult } from '../types/query.js';
 import type { FormattableQueryResult } from '../types/output.js';
+import type { LoreConfig } from '../types/config.js';
 import { mergeOptions } from './helpers/merge-options.js';
 import { buildQueryMeta } from './helpers/build-query-meta.js';
 import { parsePositiveInt } from './helpers/path-query.js';
+import { LORE_TRAILER_KEYS } from '../util/constants.js';
+import { LoreError } from '../util/errors.js';
 
 interface SearchCommandOptions {
   readonly confidence?: string;
@@ -36,6 +39,7 @@ export function registerSearchCommand(
     supersessionResolver: SupersessionResolver;
     searchFilter: SearchFilter;
     getFormatter: () => IOutputFormatter;
+    config: LoreConfig;
   },
 ): void {
   program
@@ -55,13 +59,27 @@ export function registerSearchCommand(
     .option('--max-commits <n>', 'Maximum git commits to scan (supersession may be incomplete)', parsePositiveInt)
     .action(async (_options: SearchCommandOptions, command: Command) => {
       const options = mergeOptions<SearchCommandOptions>(command);
-      const { atomRepository, supersessionResolver, searchFilter, getFormatter } = deps;
+      const { atomRepository, supersessionResolver, searchFilter, getFormatter, config } = deps;
+
+      // Validate --has trailer if specified
+      if (options.has) {
+        const isStandard = (LORE_TRAILER_KEYS as readonly string[]).includes(options.has);
+        const customWhitelist = config.trailers.custom;
+
+        // If strict mode (whitelist populated) and not a standard/whitelisted key, throw error
+        if (customWhitelist.length > 0 && !isStandard && !customWhitelist.includes(options.has)) {
+          throw new LoreError(
+            `Trailer "${options.has}" is not recognized. In this repository, you can only search for standard Lore trailers or registered custom trailers: ${customWhitelist.join(', ')}.`,
+            1,
+          );
+        }
+      }
 
       const searchOptions: SearchOptions = {
         confidence: (options.confidence as SearchOptions['confidence']) ?? null,
         scopeRisk: (options.scopeRisk as SearchOptions['scopeRisk']) ?? null,
         reversibility: (options.reversibility as SearchOptions['reversibility']) ?? null,
-        has: (options.has as TrailerKey) ?? null,
+        has: options.has ?? null,
         author: options.author ?? null,
         scope: options.scope ?? null,
         text: options.text ?? null,

--- a/src/formatters/text-formatter.ts
+++ b/src/formatters/text-formatter.ts
@@ -291,6 +291,16 @@ export class TextFormatter implements IOutputFormatter {
       }
     }
 
+    // Custom trailers
+    for (const [key, values] of trailers.custom) {
+      // Use TrailerKey type for standard trailers only, cast for shouldShow
+      if (shouldShow(key as TrailerKey)) {
+        for (const v of values) {
+          lines.push(`${this.c.dim(`${key}:`)} ${v}`);
+        }
+      }
+    }
+
     return lines;
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -150,6 +150,7 @@ async function main(): Promise<void> {
     supersessionResolver,
     searchFilter,
     getFormatter,
+    config,
   });
 
   registerLogCommand(program, {

--- a/src/services/search-filter.ts
+++ b/src/services/search-filter.ts
@@ -56,9 +56,9 @@ export class SearchFilter {
   /**
    * Check if an atom has a non-empty value for the given trailer key.
    * Uses data-driven lookup via ARRAY_TRAILER_KEYS and ENUM_TRAILER_KEYS
-   * instead of a per-key switch statement.
+   * for standard trailers, and checks the custom collection for others.
    */
-  atomHasTrailer(atom: LoreAtom, trailerKey: TrailerKey): boolean {
+  atomHasTrailer(atom: LoreAtom, trailerKey: string): boolean {
     if (trailerKey === 'Lore-id') {
       return !!atom.trailers['Lore-id'];
     }
@@ -75,7 +75,8 @@ export class SearchFilter {
       return value !== null;
     }
 
-    return false;
+    // Custom trailers
+    return atom.trailers.custom.has(trailerKey);
   }
 
   /**
@@ -98,6 +99,13 @@ export class SearchFilter {
     for (const key of ENUM_TRAILER_KEYS) {
       const value = trailers[key];
       if (value?.toLowerCase().includes(textLower)) return true;
+    }
+
+    // Check custom trailers
+    for (const [, values] of trailers.custom) {
+      for (const value of values) {
+        if (value.toLowerCase().includes(textLower)) return true;
+      }
     }
 
     return false;

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -25,7 +25,7 @@ export interface SearchOptions {
   readonly confidence: ConfidenceLevel | null;
   readonly scopeRisk: ScopeRiskLevel | null;
   readonly reversibility: ReversibilityLevel | null;
-  readonly has: TrailerKey | null;
+  readonly has: string | null;
   readonly author: string | null;
   readonly scope: string | null;
   readonly text: string | null;

--- a/tests/unit/commands/search-validation.test.ts
+++ b/tests/unit/commands/search-validation.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { Command } from 'commander';
+import { registerSearchCommand } from '../../../src/commands/search.js';
+import type { AtomRepository } from '../../../src/services/atom-repository.js';
+import type { SupersessionResolver } from '../../../src/services/supersession-resolver.js';
+import type { SearchFilter } from '../../../src/services/search-filter.js';
+import type { IOutputFormatter } from '../../../src/interfaces/output-formatter.js';
+import { LoreError } from '../../../src/util/errors.js';
+import type { LoreConfig } from '../../../src/types/config.js';
+
+describe('Search Command Validation (Perfect Mirror)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const mockDeps = (customWhitelist: string[]) => {
+    const atomRepository = {
+      findAll: vi.fn().mockResolvedValue([]),
+    } as unknown as AtomRepository;
+
+    const supersessionResolver = {
+      resolve: vi.fn().mockReturnValue(new Map()),
+      filterActive: vi.fn().mockReturnValue([]),
+    } as unknown as SupersessionResolver;
+
+    const searchFilter = {
+      applyFilters: vi.fn().mockReturnValue([]),
+    } as unknown as SearchFilter;
+
+    const formatter = {
+      formatQueryResult: vi.fn().mockReturnValue(''),
+    } as unknown as IOutputFormatter;
+
+    const config = {
+      trailers: {
+        custom: customWhitelist,
+      },
+    } as unknown as LoreConfig;
+
+    return {
+      atomRepository,
+      supersessionResolver,
+      searchFilter,
+      getFormatter: () => formatter,
+      config,
+    };
+  };
+
+  it('should allow searching for any trailer when custom list is empty (Greedy Mode)', async () => {
+    const deps = mockDeps([]);
+    const program = new Command();
+    program.exitOverride();
+    registerSearchCommand(program, deps);
+
+    // Should NOT throw
+    await program.parseAsync(['node', 'lore', 'search', '--has', 'Random-Trailer']);
+    expect(deps.atomRepository.findAll).toHaveBeenCalled();
+  });
+
+  it('should allow searching for whitelisted custom trailers in Strict Mode', async () => {
+    const deps = mockDeps(['Ticket']);
+    const program = new Command();
+    program.exitOverride();
+    registerSearchCommand(program, deps);
+
+    // Should NOT throw for whitelisted trailer
+    await program.parseAsync(['node', 'lore', 'search', '--has', 'Ticket']);
+    expect(deps.atomRepository.findAll).toHaveBeenCalled();
+  });
+
+  it('should allow searching for standard trailers even in Strict Mode', async () => {
+    const deps = mockDeps(['Ticket']);
+    const program = new Command();
+    program.exitOverride();
+    registerSearchCommand(program, deps);
+
+    // Should NOT throw for standard trailer
+    await program.parseAsync(['node', 'lore', 'search', '--has', 'Constraint']);
+    expect(deps.atomRepository.findAll).toHaveBeenCalled();
+  });
+
+  it('should throw LoreError when searching for unregistered trailer in Strict Mode', async () => {
+    const deps = mockDeps(['Ticket']);
+    const program = new Command();
+    program.exitOverride();
+    registerSearchCommand(program, deps);
+
+    // Should throw LoreError for unregistered trailer
+    try {
+      await program.parseAsync(['node', 'lore', 'search', '--has', 'Assisted-by']);
+      expect.fail('Should have thrown LoreError');
+    } catch (error) {
+      expect(error).toBeInstanceOf(LoreError);
+      expect((error as LoreError).message).toContain('is not recognized');
+      expect((error as LoreError).message).toContain('Ticket');
+    }
+  });
+});

--- a/tests/unit/services/custom-trailer-repro.test.ts
+++ b/tests/unit/services/custom-trailer-repro.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import { SearchFilter } from '../../../src/services/search-filter.js';
+import { TextFormatter } from '../../../src/formatters/text-formatter.js';
+import { CustomTrailerCollection } from '../../../src/types/custom-trailer-collection.js';
+import type { LoreAtom, LoreTrailers } from '../../../src/types/domain.js';
+import type { FormattableQueryResult } from '../../../src/types/output.js';
+
+function makeTrailers(overrides: Partial<LoreTrailers> = {}): LoreTrailers {
+  return {
+    'Lore-id': overrides['Lore-id'] ?? 'a1b2c3d4',
+    Constraint: overrides.Constraint ?? [],
+    Rejected: overrides.Rejected ?? [],
+    Confidence: overrides.Confidence ?? null,
+    'Scope-risk': overrides['Scope-risk'] ?? null,
+    Reversibility: overrides.Reversibility ?? null,
+    Directive: overrides.Directive ?? [],
+    Tested: overrides.Tested ?? [],
+    'Not-tested': overrides['Not-tested'] ?? [],
+    Supersedes: overrides.Supersedes ?? [],
+    'Depends-on': overrides['Depends-on'] ?? [],
+    Related: overrides.Related ?? [],
+    custom: overrides.custom ?? CustomTrailerCollection.empty(),
+  };
+}
+
+function makeAtom(overrides: Partial<LoreAtom> = {}): LoreAtom {
+  return {
+    loreId: overrides.loreId ?? 'a1b2c3d4',
+    commitHash: overrides.commitHash ?? 'abc1234567890',
+    date: overrides.date ?? new Date('2025-01-15T10:00:00Z'),
+    author: overrides.author ?? 'alice@example.com',
+    intent: overrides.intent ?? 'feat(auth): add login flow',
+    body: overrides.body ?? '',
+    trailers: overrides.trailers ?? makeTrailers(),
+    filesChanged: overrides.filesChanged ?? ['src/auth.ts'],
+  };
+}
+
+describe('Custom Trailer Support (Reproduction)', () => {
+  const searchFilter = new SearchFilter();
+  const textFormatter = new TextFormatter({ color: false });
+
+  describe('SearchFilter with custom trailers', () => {
+    const customTrailers = new Map<string, string[]>();
+    customTrailers.set('Ticket', ['ABC-123']);
+    customTrailers.set('Assisted-by', ['Gemini']);
+
+    const atom = makeAtom({
+      trailers: makeTrailers({
+        custom: new CustomTrailerCollection(customTrailers),
+      }),
+    });
+
+    it('should find atom when searching for custom trailer value via --text', () => {
+      const results = searchFilter.applyFilters([atom], {
+        confidence: null,
+        scopeRisk: null,
+        reversibility: null,
+        has: null,
+        author: null,
+        scope: null,
+        text: 'Gemini',
+        since: null,
+        until: null,
+        limit: null,
+        maxCommits: null,
+      });
+
+      expect(results.length).toBe(1);
+    });
+
+    it('should find atom when searching for custom trailer presence via --has', () => {
+      const results = searchFilter.applyFilters([atom], {
+        confidence: null,
+        scopeRisk: null,
+        reversibility: null,
+        has: 'Ticket',
+        author: null,
+        scope: null,
+        text: null,
+        since: null,
+        until: null,
+        limit: null,
+        maxCommits: null,
+      });
+
+      expect(results.length).toBe(1);
+    });
+  });
+
+  describe('TextFormatter with custom trailers', () => {
+    it('should include custom trailers in output', () => {
+      const customTrailers = new Map<string, string[]>();
+      customTrailers.set('Ticket', ['ABC-123']);
+      
+      const atom = makeAtom({
+        trailers: makeTrailers({
+          custom: new CustomTrailerCollection(customTrailers),
+        }),
+      });
+
+      const data: FormattableQueryResult = {
+        result: {
+          command: 'search',
+          target: 'all',
+          targetType: 'search',
+          atoms: [atom],
+          meta: { totalAtoms: 1, filteredAtoms: 1, oldest: atom.date, newest: atom.date },
+        },
+        supersessionMap: new Map(),
+        visibleTrailers: 'all',
+      };
+
+      const output = textFormatter.formatQueryResult(data);
+      
+      expect(output).toContain('Ticket: ABC-123');
+    });
+  });
+});


### PR DESCRIPTION
## Overview
This PR promotes custom trailers from "JSON-only" metadata to first-class citizens in the Lore CLI. It resolves a significant UX gap where custom trailers, despite being correctly written to git and parsed into Lore atoms, were invisible to the terminal UI and ignored by the search engine.

### The Problem
Previously, if a project used custom trailers (e.g., `Ticket`, `Assisted-by`):
1. **Silent Search Failures**: Running `lore search --has Ticket` would return "No lore atoms found" even if every commit had a Ticket trailer. This occurred because the `SearchFilter` only checked a hardcoded list of standard protocol keys.
2. **Hidden Metadata**: The standard text output (`lore log`, `lore context`) simply omitted custom trailers, making the human-readable view incomplete compared to the JSON output.
3. **Inconsistent Validation**: There was no enforcement at the command level to ensure that searches for custom trailers aligned with the project's configured vocabulary.

### Key Changes
This PR implements a "Perfect Mirror" logic that ensures display and search behavior consistently follows the parser's configuration.

#### 1. First-Class Search Support (`src/services/search-filter.ts`)
- **`--has`**: Updated `atomHasTrailer` to check the `custom` map if the key is not part of the standard protocol.
- **`--text`**: Updated `atomMatchesText` to include custom trailer values in full-text searches.

#### 2. Enhanced Terminal Visibility (`src/formatters/text-formatter.ts`)
- Custom trailers are now rendered in terminal output. They are styled in a `dim` (gray) color to distinguish them from standard trailers while ensuring the narrative is complete.

#### 3. "Perfect Mirror" Validation (`src/commands/search.ts`)
- The `search` command now validates the `--has` parameter against the project's configuration:
    - **Greedy Mode** (custom list is empty): Accepts any string.
    - **Strict Mode** (custom list populated): Only accepts standard trailers or whitelisted custom trailers.
- This prevents confusing empty results by informing the user when they are searching for a trailer that Lore is not currently tracking.

#### 4. Type Safety & Infrastructure
- Relaxed `SearchOptions` types to allow custom string keys.
- Properly wired `LoreConfig` into the search command dependency injection chain (`src/main.ts`).

### Verification Results
- **Unit Tests**: 7 new/updated tests covering SearchFilter, TextFormatter, and the new command-level validation logic. All 431 total tests pass.
- **Type Check**: `tsc --noEmit` is clean.
- **Manual E2E**: Verified greedy/strict transitions in a temporary repository. Confirming that searching for `--text Gemini` now correctly finds atoms where Gemini is listed as a custom trailer.

### Why this matters
Lore's power lies in its ability to capture structured decision context. By making custom trailers searchable and visible, we allow teams to extend the protocol with their own domains (ticketing, AI attribution, etc.) without losing the ability to query that knowledge directly from the CLI.